### PR TITLE
feat: types and API client for instructions, ingredients, comments

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,104 @@
+name: Deploy Xom Appétit Frontend
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      skip_cache_invalidation:
+        description: "Skip CloudFront cache invalidation"
+        required: false
+        default: "false"
+
+env:
+  AWS_REGION: us-east-1
+  S3_BUCKET: xomappetit.xomware.com
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build (Next.js static export)
+        env:
+          NEXT_PUBLIC_API_URL: https://api.xomappetit.xomware.com
+          NEXT_PUBLIC_AUTH_HASH: ${{ secrets.PUBLIC_AUTH_HASH }}
+        run: npm run build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Sync hashed assets to S3 (long cache)
+        run: |
+          aws s3 sync ./out s3://${S3_BUCKET} --delete \
+            --exclude "index.html" \
+            --exclude "*.html" \
+            --cache-control "public, max-age=31536000, immutable"
+
+      - name: Sync HTML to S3 (no cache)
+        run: |
+          aws s3 sync ./out s3://${S3_BUCKET} \
+            --exclude "*" \
+            --include "*.html" \
+            --cache-control "no-cache, no-store, must-revalidate" \
+            --content-type "text/html"
+
+      - name: Invalidate CloudFront
+        if: inputs.skip_cache_invalidation != 'true'
+        run: |
+          DISTRIBUTION_ID=$(aws cloudfront list-distributions \
+            --query "DistributionList.Items[?Aliases.Items[?@ == '${S3_BUCKET}']].Id" \
+            --output text)
+
+          if [ -z "$DISTRIBUTION_ID" ]; then
+            echo "::error::No CloudFront distribution found for ${S3_BUCKET}"
+            exit 1
+          fi
+
+          echo "Invalidating CloudFront distribution: $DISTRIBUTION_ID"
+          INVALIDATION_ID=$(aws cloudfront create-invalidation \
+            --distribution-id "$DISTRIBUTION_ID" \
+            --paths "/*" \
+            --query 'Invalidation.Id' --output text)
+
+          echo "Invalidation ID: $INVALIDATION_ID — waiting for completion..."
+          TIMEOUT=300
+          ELAPSED=0
+          while [ $ELAPSED -lt $TIMEOUT ]; do
+            STATUS=$(aws cloudfront get-invalidation \
+              --distribution-id "$DISTRIBUTION_ID" \
+              --id "$INVALIDATION_ID" \
+              --query 'Invalidation.Status' --output text)
+            echo "  Status: $STATUS (${ELAPSED}s)"
+            if [ "$STATUS" = "Completed" ]; then
+              echo "✓ CloudFront invalidation completed"
+              break
+            fi
+            sleep 10
+            ELAPSED=$((ELAPSED + 10))
+          done
+
+      - name: Summary
+        if: success()
+        run: |
+          echo "## Deployed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **S3:** s3://${S3_BUCKET}" >> $GITHUB_STEP_SUMMARY
+          echo "- **URL:** https://${S3_BUCKET}" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Meals Frontend
+# Xom Appétit — Frontend
 
-A meals tracking web application built with **Next.js 15**, **TypeScript**, and **Tailwind CSS**. Track meals, filter by various criteria, and rate them — all in a responsive dark-themed UI.
+Web app for **Xom Appétit**, a home-cooking tracker. Built with **Next.js 15**, **TypeScript**, and **Tailwind CSS**. Log meals, ingredients, and cooking steps; filter and rate them in a responsive dark-themed UI.
 
 ![Next.js](https://img.shields.io/badge/Next.js-15-black) ![TypeScript](https://img.shields.io/badge/TypeScript-5-blue) ![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-4-38bdf8)
 
@@ -22,7 +22,7 @@ A meals tracking web application built with **Next.js 15**, **TypeScript**, and 
 | Language | [TypeScript](https://www.typescriptlang.org/) |
 | Styling | [Tailwind CSS](https://tailwindcss.com/) |
 | Data Fetching | [SWR](https://swr.vercel.app/) |
-| API | REST → [api.xomware.com](https://api.xomware.com) |
+| API | Verb-style → [api.xomappetit.xomware.com](https://api.xomappetit.xomware.com) |
 
 ## Getting Started
 
@@ -35,8 +35,8 @@ A meals tracking web application built with **Next.js 15**, **TypeScript**, and 
 
 ```bash
 # Clone the repo
-git clone https://github.com/Xomware/meals-frontend.git
-cd meals-frontend
+git clone https://github.com/Xomware/xomappetit-frontend.git
+cd xomappetit-frontend
 
 # Install dependencies
 npm install

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "meals-frontend",
+  "name": "xomappetit-frontend",
   "version": "1.0.0",
-  "description": "",
+  "description": "Xom Appétit — meal-tracking web app",
   "main": "index.js",
   "scripts": {
     "dev": "next dev",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,1 +1,51 @@
 @import "tailwindcss";
+
+/* Xom Appétit brand theme — loud/maximalist, coral-led */
+@theme {
+  --color-coral-50: #fff1f1;
+  --color-coral-100: #ffdedf;
+  --color-coral-200: #ffc1c3;
+  --color-coral-300: #ff9598;
+  --color-coral-400: #ff6b6b;
+  --color-coral-500: #f04444;
+  --color-coral-600: #dc2626;
+  --color-coral-700: #b91c1c;
+  --color-coral-800: #911414;
+  --color-coral-900: #6e0f0f;
+
+  --color-flame-400: #ffa94d;
+  --color-flame-500: #ff7b1c;
+
+  --font-display: "Bebas Neue", "Anton", "Oswald", system-ui, sans-serif;
+  --font-body: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+}
+
+/* Subtle "stamped" border for loud cards */
+.brand-stamp {
+  box-shadow:
+    0 0 0 1px rgba(255, 107, 107, 0.35),
+    0 8px 32px -8px rgba(255, 107, 107, 0.15),
+    0 1px 0 rgba(255, 255, 255, 0.04) inset;
+}
+
+/* "Yes chef" stamp for strong rating display */
+.chef-stamp {
+  font-family: var(--font-display);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: linear-gradient(135deg, var(--color-coral-400), var(--color-flame-500));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+/* Underline accent on h1s — coral gradient bar */
+.brand-bar::after {
+  content: "";
+  display: block;
+  width: 56px;
+  height: 4px;
+  border-radius: 2px;
+  margin-top: 6px;
+  background: linear-gradient(90deg, var(--color-coral-400), var(--color-flame-500));
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,14 +2,14 @@ import type { Metadata } from 'next';
 import './globals.css';
 
 export const metadata: Metadata = {
-  title: 'Meals | Xomware',
-  description: 'Meal tracker and planner',
+  title: 'Xom Appétit',
+  description: 'Cook it. Log it. Rate it. Get roasted.',
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className="bg-gray-950 text-gray-100 min-h-screen antialiased">
+      <body className="bg-zinc-950 text-zinc-100 min-h-screen antialiased">
         {children}
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,23 +2,43 @@
 import { useState, useMemo } from 'react';
 import { useMeals } from '@/lib/hooks';
 import { Filters, Meal, ViewMode } from '@/types';
+import Header from '@/components/Header';
 import FilterBar from '@/components/FilterBar';
 import MealTable from '@/components/MealTable';
 import MealCard from '@/components/MealCard';
 import AddMealModal from '@/components/AddMealModal';
+import EditMealModal from '@/components/EditMealModal';
 import RateMealModal from '@/components/RateMealModal';
+import MealDetailModal from '@/components/MealDetailModal';
+import { MASCOTS, mascotFor } from '@/components/Mascot';
 
-const defaultFilters: Filters = { proteinSource: '', difficulty: '', cookedStatus: 'all', timeMin: 0, timeMax: 999 };
+const defaultFilters: Filters = {
+  proteinSource: '',
+  difficulty: '',
+  cookedStatus: 'all',
+  timeMin: 0,
+  timeMax: 999,
+};
 
 export default function Home() {
-  const { meals, isLoading, addMeal, toggleCooked, rateMeal, deleteMeal } = useMeals();
-  const [view, setView] = useState<ViewMode>('table');
+  const {
+    meals,
+    isLoading,
+    addMeal,
+    editMeal,
+    toggleCooked,
+    rateMeal,
+    deleteMeal,
+  } = useMeals();
+  const [view, setView] = useState<ViewMode>('card');
   const [filters, setFilters] = useState<Filters>(defaultFilters);
   const [addOpen, setAddOpen] = useState(false);
+  const [detailMeal, setDetailMeal] = useState<Meal | null>(null);
+  const [editingMeal, setEditingMeal] = useState<Meal | null>(null);
   const [ratingMeal, setRatingMeal] = useState<Meal | null>(null);
 
   const filtered = useMemo(() => {
-    return meals.filter(m => {
+    return meals.filter((m) => {
       if (filters.proteinSource && m.proteinSource !== filters.proteinSource) return false;
       if (filters.difficulty && m.difficulty !== filters.difficulty) return false;
       if (filters.cookedStatus === 'cooked' && !m.cooked) return false;
@@ -29,52 +49,126 @@ export default function Home() {
     });
   }, [meals, filters]);
 
+  const cookedCount = useMemo(() => meals.filter((m) => m.cooked).length, [meals]);
+
+  // Keep the detail modal in sync if the meal underneath is updated/deleted
+  const detail = detailMeal
+    ? meals.find((m) => m.id === detailMeal.id) ?? null
+    : null;
+  const editing = editingMeal
+    ? meals.find((m) => m.id === editingMeal.id) ?? null
+    : null;
+  const rating = ratingMeal
+    ? meals.find((m) => m.id === ratingMeal.id) ?? null
+    : null;
+
   return (
-    <div className="max-w-6xl mx-auto px-4 py-6">
-      <header className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">
-        <div>
-          <h1 className="text-2xl font-bold">🍽️ Meals</h1>
-          <p className="text-gray-400 text-sm">{meals.length} meals tracked</p>
-        </div>
-        <div className="flex gap-2">
-          <div className="flex bg-gray-800 rounded-lg p-0.5">
-            <button
-              onClick={() => setView('table')}
-              className={`px-3 py-1.5 rounded-md text-sm transition ${view === 'table' ? 'bg-gray-700 text-white' : 'text-gray-400 hover:text-white'}`}
-            >Table</button>
-            <button
-              onClick={() => setView('card')}
-              className={`px-3 py-1.5 rounded-md text-sm transition ${view === 'card' ? 'bg-gray-700 text-white' : 'text-gray-400 hover:text-white'}`}
-            >Cards</button>
-          </div>
-          <button
-            onClick={() => setAddOpen(true)}
-            className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg text-sm font-medium transition"
-          >+ Add Meal</button>
-        </div>
-      </header>
+    <div>
+      <Header
+        mealCount={meals.length}
+        cookedCount={cookedCount}
+        view={view}
+        onViewChange={setView}
+        onAdd={() => setAddOpen(true)}
+      />
 
-      <div className="mb-6">
+      <main className="max-w-6xl mx-auto px-4 py-6 space-y-6">
         <FilterBar filters={filters} onChange={setFilters} meals={meals} />
-      </div>
 
-      {isLoading ? (
-        <div className="text-center text-gray-500 py-12">Loading...</div>
-      ) : view === 'table' ? (
-        <MealTable meals={filtered} onToggleCooked={toggleCooked} onRate={setRatingMeal} onDelete={deleteMeal} />
-      ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {filtered.map(meal => (
-            <MealCard key={meal.id} meal={meal} onToggleCooked={toggleCooked} onRate={setRatingMeal} onDelete={deleteMeal} />
-          ))}
-          {filtered.length === 0 && (
-            <div className="col-span-full text-center text-gray-500 py-12">No meals found. Add one to get started!</div>
-          )}
-        </div>
-      )}
+        {isLoading ? (
+          <LoadingState />
+        ) : meals.length === 0 ? (
+          <EmptyState onAdd={() => setAddOpen(true)} />
+        ) : view === 'table' ? (
+          <MealTable
+            meals={filtered}
+            onOpen={setDetailMeal}
+            onToggleCooked={toggleCooked}
+            onRate={setRatingMeal}
+            onDelete={deleteMeal}
+          />
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {filtered.map((meal) => (
+              <MealCard
+                key={meal.id}
+                meal={meal}
+                onOpen={setDetailMeal}
+                onToggleCooked={toggleCooked}
+                onRate={setRatingMeal}
+                onDelete={deleteMeal}
+              />
+            ))}
+            {filtered.length === 0 && (
+              <div className="col-span-full text-center text-zinc-500 py-12 italic">
+                No meals match. Loosen the filters or log a new one.
+              </div>
+            )}
+          </div>
+        )}
+      </main>
 
-      <AddMealModal open={addOpen} onClose={() => setAddOpen(false)} onAdd={addMeal} />
-      <RateMealModal open={!!ratingMeal} meal={ratingMeal} onClose={() => setRatingMeal(null)} onRate={rateMeal} />
+      <AddMealModal
+        open={addOpen}
+        onClose={() => setAddOpen(false)}
+        onAdd={addMeal}
+      />
+      <MealDetailModal
+        open={!!detail}
+        meal={detail}
+        onClose={() => setDetailMeal(null)}
+        onEdit={(m) => {
+          setDetailMeal(null);
+          setEditingMeal(m);
+        }}
+        onRate={(m) => {
+          setDetailMeal(null);
+          setRatingMeal(m);
+        }}
+        onToggleCooked={toggleCooked}
+      />
+      <EditMealModal
+        open={!!editing}
+        meal={editing}
+        onClose={() => setEditingMeal(null)}
+        onEdit={editMeal}
+      />
+      <RateMealModal
+        open={!!rating}
+        meal={rating}
+        onClose={() => setRatingMeal(null)}
+        onRate={rateMeal}
+      />
+    </div>
+  );
+}
+
+function LoadingState() {
+  return (
+    <div className="text-center py-16">
+      <div className="text-coral-400 text-3xl animate-pulse">🔥</div>
+      <div className="text-zinc-500 text-sm mt-2 italic">heating up the kitchen…</div>
+    </div>
+  );
+}
+
+function EmptyState({ onAdd }: { onAdd: () => void }) {
+  const mascot = MASCOTS[mascotFor('empty-state')];
+  return (
+    <div className="text-center py-16 border border-dashed border-zinc-800 rounded-xl">
+      <div className="text-5xl mb-3">{mascot.emoji}</div>
+      <h2 className="font-display text-2xl font-black uppercase tracking-wide">
+        {mascot.caption}
+      </h2>
+      <p className="text-zinc-400 text-sm mt-2 max-w-sm mx-auto">
+        Nothing logged yet. Add your first meal — {mascot.name} will judge you accordingly.
+      </p>
+      <button
+        onClick={onAdd}
+        className="mt-5 bg-gradient-to-r from-coral-500 to-coral-400 hover:from-coral-400 hover:to-coral-300 text-white font-bold uppercase tracking-wider px-6 py-2.5 rounded-lg transition shadow-lg shadow-coral-500/20"
+      >
+        Log your first meal
+      </button>
     </div>
   );
 }

--- a/src/components/AddMealModal.tsx
+++ b/src/components/AddMealModal.tsx
@@ -1,6 +1,6 @@
 'use client';
-import { useState } from 'react';
 import Modal from './Modal';
+import MealForm, { MealFormValues } from './MealForm';
 import { Meal } from '@/types';
 
 interface Props {
@@ -9,96 +9,15 @@ interface Props {
   onAdd: (meal: Omit<Meal, 'id' | 'createdAt' | 'cooked'>) => Promise<void>;
 }
 
-const DIFFICULTIES = ['Easy', 'Medium', 'Hard'] as const;
-
 export default function AddMealModal({ open, onClose, onAdd }: Props) {
-  const [name, setName] = useState('');
-  const [timeMinutes, setTimeMinutes] = useState(30);
-  const [difficulty, setDifficulty] = useState<'Easy' | 'Medium' | 'Hard'>('Medium');
-  const [proteinSource, setProteinSource] = useState('');
-  const [ingredients, setIngredients] = useState('');
-  const [calories, setCalories] = useState(0);
-  const [protein, setProtein] = useState(0);
-  const [carbs, setCarbs] = useState(0);
-  const [fat, setFat] = useState(0);
-  const [submitting, setSubmitting] = useState(false);
-
-  const reset = () => {
-    setName(''); setTimeMinutes(30); setDifficulty('Medium');
-    setProteinSource(''); setIngredients('');
-    setCalories(0); setProtein(0); setCarbs(0); setFat(0);
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setSubmitting(true);
-    await onAdd({
-      name,
-      timeMinutes,
-      difficulty,
-      proteinSource,
-      ingredients: ingredients.split(',').map(s => s.trim()).filter(Boolean),
-      macros: { calories, protein, carbs, fat },
-    });
-    reset();
-    setSubmitting(false);
+  const handleSubmit = async (values: MealFormValues) => {
+    await onAdd(values);
     onClose();
   };
 
-  const inputCls = 'w-full bg-gray-800 border border-gray-600 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500';
-  const labelCls = 'block text-sm font-medium text-gray-300 mb-1';
-
   return (
-    <Modal open={open} onClose={onClose} title="Add Meal">
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <div>
-          <label className={labelCls}>Name *</label>
-          <input className={inputCls} value={name} onChange={e => setName(e.target.value)} required />
-        </div>
-        <div className="grid grid-cols-2 gap-3">
-          <div>
-            <label className={labelCls}>Time (min)</label>
-            <input type="number" className={inputCls} value={timeMinutes} onChange={e => setTimeMinutes(+e.target.value)} min={1} />
-          </div>
-          <div>
-            <label className={labelCls}>Difficulty</label>
-            <select className={inputCls} value={difficulty} onChange={e => setDifficulty(e.target.value as typeof difficulty)}>
-              {DIFFICULTIES.map(d => <option key={d}>{d}</option>)}
-            </select>
-          </div>
-        </div>
-        <div>
-          <label className={labelCls}>Protein Source</label>
-          <input className={inputCls} value={proteinSource} onChange={e => setProteinSource(e.target.value)} placeholder="e.g. Chicken, Tofu" />
-        </div>
-        <div>
-          <label className={labelCls}>Ingredients (comma separated)</label>
-          <textarea className={inputCls + ' h-20'} value={ingredients} onChange={e => setIngredients(e.target.value)} placeholder="chicken, rice, broccoli..." />
-        </div>
-        <div>
-          <label className={labelCls}>Macros</label>
-          <div className="grid grid-cols-4 gap-2">
-            {[
-              ['Cal', calories, setCalories],
-              ['Protein', protein, setProtein],
-              ['Carbs', carbs, setCarbs],
-              ['Fat', fat, setFat],
-            ].map(([label, val, setter]) => (
-              <div key={label as string}>
-                <span className="text-xs text-gray-400">{label as string}</span>
-                <input type="number" className={inputCls} value={val as number} onChange={e => (setter as (v: number) => void)(+e.target.value)} min={0} />
-              </div>
-            ))}
-          </div>
-        </div>
-        <button
-          type="submit"
-          disabled={submitting || !name.trim()}
-          className="w-full bg-blue-600 hover:bg-blue-700 disabled:opacity-50 text-white font-medium py-2 px-4 rounded-lg transition"
-        >
-          {submitting ? 'Adding...' : 'Add Meal'}
-        </button>
-      </form>
+    <Modal open={open} onClose={onClose} title="Log a new meal">
+      <MealForm submitLabel="Add meal" onSubmit={handleSubmit} />
     </Modal>
   );
 }

--- a/src/components/CommentsSection.tsx
+++ b/src/components/CommentsSection.tsx
@@ -1,0 +1,136 @@
+'use client';
+import { useState } from 'react';
+import { useMealComments } from '@/lib/hooks';
+import { mascotFor, MASCOTS } from './Mascot';
+
+interface Props {
+  mealId: string;
+}
+
+const inputCls =
+  'w-full bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-coral-400 focus:border-transparent';
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const min = Math.round(diff / 60_000);
+  if (min < 1) return 'just now';
+  if (min < 60) return `${min}m ago`;
+  const hrs = Math.round(min / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.round(hrs / 24);
+  if (days < 30) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+export default function CommentsSection({ mealId }: Props) {
+  const { comments, isLoading, addComment, deleteComment } = useMealComments(mealId);
+  const [draft, setDraft] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!draft.trim()) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await addComment(draft.trim());
+      setDraft('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to post comment');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-400">
+          Comments
+        </h3>
+        <span className="text-xs text-zinc-500">
+          {comments.length === 0
+            ? 'no notes yet'
+            : `${comments.length} ${comments.length === 1 ? 'note' : 'notes'}`}
+        </span>
+      </div>
+
+      {isLoading ? (
+        <div className="text-zinc-500 text-sm italic">Loading…</div>
+      ) : comments.length === 0 ? (
+        <div className="text-zinc-500 text-sm italic border border-dashed border-zinc-800 rounded-lg p-3">
+          Drop a note when you cook this — what worked, what flopped, what you'd swap next time.
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {comments.map((c) => {
+            const mascot = MASCOTS[mascotFor(c.commentId)];
+            return (
+              <li
+                key={c.commentId}
+                className="bg-zinc-900/60 border border-zinc-800 rounded-lg p-3 group"
+              >
+                <div className="flex items-start gap-2">
+                  <span
+                    className="h-7 w-7 rounded-full grid place-items-center text-sm flex-shrink-0 mt-0.5"
+                    style={{
+                      background: `${mascot.accent}22`,
+                      border: `1px solid ${mascot.accent}66`,
+                    }}
+                    aria-hidden="true"
+                  >
+                    {mascot.emoji}
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <div className="text-xs text-zinc-500 mb-0.5">
+                      <span className="text-zinc-300 font-semibold">{mascot.name}</span>
+                      <span className="mx-1.5 text-zinc-700">·</span>
+                      {timeAgo(c.createdAt)}
+                    </div>
+                    <div className="text-sm text-zinc-200 whitespace-pre-wrap break-words">
+                      {c.body}
+                    </div>
+                  </div>
+                  <button
+                    onClick={() => deleteComment(c.commentId)}
+                    className="text-zinc-600 hover:text-coral-400 text-xs opacity-0 group-hover:opacity-100 transition"
+                    aria-label="Delete comment"
+                  >
+                    delete
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <form onSubmit={handleSubmit} className="space-y-2 pt-1">
+        <textarea
+          rows={2}
+          maxLength={2000}
+          placeholder="Add a note… (e.g. 'Subbed quinoa for rice, was great')"
+          className={inputCls + ' resize-y'}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+        />
+        {error && (
+          <div className="text-xs text-coral-300">{error}</div>
+        )}
+        <div className="flex justify-between items-center">
+          <span className="text-xs text-zinc-600">
+            {draft.length}/2000
+          </span>
+          <button
+            type="submit"
+            disabled={submitting || !draft.trim()}
+            className="text-xs font-semibold uppercase tracking-wider bg-coral-500 hover:bg-coral-400 disabled:opacity-40 disabled:cursor-not-allowed text-white px-4 py-1.5 rounded-md transition"
+          >
+            {submitting ? 'Posting…' : 'Post note'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/components/EditMealModal.tsx
+++ b/src/components/EditMealModal.tsx
@@ -1,0 +1,26 @@
+'use client';
+import Modal from './Modal';
+import MealForm, { MealFormValues } from './MealForm';
+import { Meal } from '@/types';
+
+interface Props {
+  open: boolean;
+  meal: Meal | null;
+  onClose: () => void;
+  onEdit: (id: string, fields: MealFormValues) => Promise<void>;
+}
+
+export default function EditMealModal({ open, meal, onClose, onEdit }: Props) {
+  if (!meal) return null;
+
+  const handleSubmit = async (values: MealFormValues) => {
+    await onEdit(meal.id, values);
+    onClose();
+  };
+
+  return (
+    <Modal open={open} onClose={onClose} title={`Edit: ${meal.name}`}>
+      <MealForm initial={meal} submitLabel="Save changes" onSubmit={handleSubmit} />
+    </Modal>
+  );
+}

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -7,22 +7,35 @@ interface Props {
   meals: Meal[];
 }
 
+const cls =
+  'bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-coral-400 focus:border-transparent';
+const labelCls = 'block text-[10px] uppercase tracking-wider text-zinc-500 mb-1';
+
 export default function FilterBar({ filters, onChange, meals }: Props) {
-  const proteins = [...new Set(meals.map(m => m.proteinSource).filter(Boolean))];
-  const cls = 'bg-gray-800 border border-gray-600 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500';
+  const proteins = [...new Set(meals.map((m) => m.proteinSource).filter(Boolean))];
 
   return (
-    <div className="flex flex-wrap gap-3 items-end">
+    <div className="flex flex-wrap gap-3 items-end bg-zinc-900/40 border border-zinc-800 rounded-xl p-3">
       <div>
-        <label className="block text-xs text-gray-400 mb-1">Protein</label>
-        <select className={cls} value={filters.proteinSource} onChange={e => onChange({ ...filters, proteinSource: e.target.value })}>
+        <label className={labelCls}>Protein</label>
+        <select
+          className={cls}
+          value={filters.proteinSource}
+          onChange={(e) => onChange({ ...filters, proteinSource: e.target.value })}
+        >
           <option value="">All</option>
-          {proteins.map(p => <option key={p}>{p}</option>)}
+          {proteins.map((p) => (
+            <option key={p}>{p}</option>
+          ))}
         </select>
       </div>
       <div>
-        <label className="block text-xs text-gray-400 mb-1">Difficulty</label>
-        <select className={cls} value={filters.difficulty} onChange={e => onChange({ ...filters, difficulty: e.target.value })}>
+        <label className={labelCls}>Difficulty</label>
+        <select
+          className={cls}
+          value={filters.difficulty}
+          onChange={(e) => onChange({ ...filters, difficulty: e.target.value })}
+        >
           <option value="">All</option>
           <option>Easy</option>
           <option>Medium</option>
@@ -30,19 +43,37 @@ export default function FilterBar({ filters, onChange, meals }: Props) {
         </select>
       </div>
       <div>
-        <label className="block text-xs text-gray-400 mb-1">Status</label>
-        <select className={cls} value={filters.cookedStatus} onChange={e => onChange({ ...filters, cookedStatus: e.target.value })}>
+        <label className={labelCls}>Status</label>
+        <select
+          className={cls}
+          value={filters.cookedStatus}
+          onChange={(e) => onChange({ ...filters, cookedStatus: e.target.value })}
+        >
           <option value="all">All</option>
           <option value="cooked">Cooked</option>
-          <option value="uncooked">Not Cooked</option>
+          <option value="uncooked">Not yet</option>
         </select>
       </div>
       <div>
-        <label className="block text-xs text-gray-400 mb-1">Time (min)</label>
+        <label className={labelCls}>Time (min)</label>
         <div className="flex gap-1 items-center">
-          <input type="number" className={cls + ' w-16'} value={filters.timeMin} onChange={e => onChange({ ...filters, timeMin: +e.target.value })} min={0} placeholder="0" />
-          <span className="text-gray-500">–</span>
-          <input type="number" className={cls + ' w-16'} value={filters.timeMax} onChange={e => onChange({ ...filters, timeMax: +e.target.value })} min={0} placeholder="∞" />
+          <input
+            type="number"
+            className={cls + ' w-16'}
+            value={filters.timeMin}
+            onChange={(e) => onChange({ ...filters, timeMin: +e.target.value })}
+            min={0}
+            placeholder="0"
+          />
+          <span className="text-zinc-600">–</span>
+          <input
+            type="number"
+            className={cls + ' w-16'}
+            value={filters.timeMax}
+            onChange={(e) => onChange({ ...filters, timeMax: +e.target.value })}
+            min={0}
+            placeholder="∞"
+          />
         </div>
       </div>
     </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,63 @@
+'use client';
+import { ViewMode } from '@/types';
+
+interface Props {
+  mealCount: number;
+  cookedCount: number;
+  view: ViewMode;
+  onViewChange: (v: ViewMode) => void;
+  onAdd: () => void;
+}
+
+export default function Header({ mealCount, cookedCount, view, onViewChange, onAdd }: Props) {
+  return (
+    <header className="border-b border-zinc-800 bg-gradient-to-b from-zinc-950 to-zinc-950/80 backdrop-blur sticky top-0 z-30">
+      <div className="max-w-6xl mx-auto px-4 py-4 flex flex-col sm:flex-row sm:items-end justify-between gap-4">
+        <div>
+          <h1 className="text-3xl sm:text-4xl font-black tracking-tight brand-bar">
+            <span className="chef-stamp">Xom Appétit</span>
+          </h1>
+          <p className="text-zinc-400 text-sm mt-2">
+            <span className="text-coral-400 font-semibold">{mealCount}</span> meals logged
+            {mealCount > 0 && (
+              <>
+                <span className="mx-1.5 text-zinc-600">·</span>
+                <span className="text-emerald-400 font-semibold">{cookedCount}</span> cooked
+              </>
+            )}
+          </p>
+        </div>
+        <div className="flex gap-2 items-center">
+          <div className="flex bg-zinc-900 rounded-lg p-0.5 border border-zinc-800">
+            <button
+              onClick={() => onViewChange('table')}
+              className={`px-3 py-1.5 rounded-md text-sm transition ${
+                view === 'table'
+                  ? 'bg-zinc-800 text-white'
+                  : 'text-zinc-500 hover:text-zinc-200'
+              }`}
+            >
+              Table
+            </button>
+            <button
+              onClick={() => onViewChange('card')}
+              className={`px-3 py-1.5 rounded-md text-sm transition ${
+                view === 'card'
+                  ? 'bg-zinc-800 text-white'
+                  : 'text-zinc-500 hover:text-zinc-200'
+              }`}
+            >
+              Cards
+            </button>
+          </div>
+          <button
+            onClick={onAdd}
+            className="bg-gradient-to-r from-coral-500 to-coral-400 hover:from-coral-400 hover:to-coral-300 text-white px-4 py-2 rounded-lg text-sm font-bold uppercase tracking-wide transition shadow-lg shadow-coral-500/20"
+          >
+            + Log a meal
+          </button>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/IngredientsEditor.tsx
+++ b/src/components/IngredientsEditor.tsx
@@ -1,0 +1,78 @@
+'use client';
+import { Ingredient } from '@/types';
+
+interface Props {
+  ingredients: Ingredient[];
+  onChange: (ingredients: Ingredient[]) => void;
+}
+
+const inputCls =
+  'bg-zinc-900 border border-zinc-700 rounded-md px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-coral-400 focus:border-transparent';
+
+export default function IngredientsEditor({ ingredients, onChange }: Props) {
+  const update = (i: number, patch: Partial<Ingredient>) => {
+    const next = ingredients.slice();
+    next[i] = { ...next[i], ...patch };
+    onChange(next);
+  };
+  const add = () => onChange([...ingredients, { name: '', quantity: null, unit: null }]);
+  const remove = (i: number) => onChange(ingredients.filter((_, idx) => idx !== i));
+
+  return (
+    <div className="space-y-2">
+      {ingredients.length === 0 && (
+        <div className="text-xs text-zinc-500 italic">
+          No ingredients yet. Add your first one ↓
+        </div>
+      )}
+      {ingredients.map((ing, i) => (
+        <div key={i} className="grid grid-cols-[80px_80px_1fr_auto] gap-2 items-center">
+          <input
+            type="number"
+            min={0}
+            step="0.25"
+            placeholder="qty"
+            className={inputCls}
+            value={ing.quantity ?? ''}
+            onChange={(e) =>
+              update(i, {
+                quantity: e.target.value === '' ? null : Number(e.target.value),
+              })
+            }
+          />
+          <input
+            type="text"
+            placeholder="unit"
+            className={inputCls}
+            value={ing.unit ?? ''}
+            onChange={(e) =>
+              update(i, { unit: e.target.value || null })
+            }
+          />
+          <input
+            type="text"
+            placeholder="name (e.g. chicken breast)"
+            className={inputCls}
+            value={ing.name}
+            onChange={(e) => update(i, { name: e.target.value })}
+          />
+          <button
+            type="button"
+            onClick={() => remove(i)}
+            className="text-zinc-500 hover:text-coral-400 text-lg leading-none w-7 h-7 grid place-items-center"
+            aria-label="Remove ingredient"
+          >
+            ×
+          </button>
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={add}
+        className="text-xs font-semibold uppercase tracking-wider text-coral-400 hover:text-coral-300 mt-1"
+      >
+        + Add ingredient
+      </button>
+    </div>
+  );
+}

--- a/src/components/InstructionsEditor.tsx
+++ b/src/components/InstructionsEditor.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+interface Props {
+  steps: string[];
+  onChange: (steps: string[]) => void;
+}
+
+const inputCls =
+  'flex-1 bg-zinc-900 border border-zinc-700 rounded-md px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-coral-400 focus:border-transparent';
+
+export default function InstructionsEditor({ steps, onChange }: Props) {
+  const update = (i: number, val: string) => {
+    const next = steps.slice();
+    next[i] = val;
+    onChange(next);
+  };
+  const add = () => onChange([...steps, '']);
+  const remove = (i: number) => onChange(steps.filter((_, idx) => idx !== i));
+  const move = (i: number, dir: -1 | 1) => {
+    const j = i + dir;
+    if (j < 0 || j >= steps.length) return;
+    const next = steps.slice();
+    [next[i], next[j]] = [next[j], next[i]];
+    onChange(next);
+  };
+
+  return (
+    <div className="space-y-2">
+      {steps.length === 0 && (
+        <div className="text-xs text-zinc-500 italic">
+          No steps yet. Add your first instruction ↓
+        </div>
+      )}
+      {steps.map((step, i) => (
+        <div key={i} className="flex items-start gap-2">
+          <span className="mt-2 w-6 h-6 rounded-full bg-coral-500/20 text-coral-400 text-xs grid place-items-center font-bold flex-shrink-0">
+            {i + 1}
+          </span>
+          <textarea
+            rows={1}
+            placeholder={`Step ${i + 1}`}
+            className={inputCls + ' resize-y min-h-[36px]'}
+            value={step}
+            onChange={(e) => update(i, e.target.value)}
+          />
+          <div className="flex flex-col gap-0.5">
+            <button
+              type="button"
+              onClick={() => move(i, -1)}
+              disabled={i === 0}
+              className="text-zinc-500 hover:text-zinc-200 disabled:opacity-30 text-xs w-6 h-4 leading-none"
+              aria-label="Move up"
+            >
+              ▲
+            </button>
+            <button
+              type="button"
+              onClick={() => move(i, 1)}
+              disabled={i === steps.length - 1}
+              className="text-zinc-500 hover:text-zinc-200 disabled:opacity-30 text-xs w-6 h-4 leading-none"
+              aria-label="Move down"
+            >
+              ▼
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={() => remove(i)}
+            className="text-zinc-500 hover:text-coral-400 text-lg leading-none w-7 h-7 grid place-items-center mt-0.5"
+            aria-label="Remove step"
+          >
+            ×
+          </button>
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={add}
+        className="text-xs font-semibold uppercase tracking-wider text-coral-400 hover:text-coral-300 mt-1"
+      >
+        + Add step
+      </button>
+    </div>
+  );
+}

--- a/src/components/Mascot.tsx
+++ b/src/components/Mascot.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+/**
+ * Three-mascot roster for Xom Appétit. Real illustrations land later;
+ * for now each mascot has a tag, accent color, and a quick caption used
+ * for empty states and toasts.
+ */
+export type MascotKey = 'boyardee' | 'ramsay' | 'fieri';
+
+export interface MascotProfile {
+  key: MascotKey;
+  name: string;
+  caption: string;
+  emoji: string;
+  accent: string;
+}
+
+export const MASCOTS: Record<MascotKey, MascotProfile> = {
+  boyardee: {
+    key: 'boyardee',
+    name: 'Xom Boyardee',
+    caption: "What's cookin'?",
+    emoji: '👨‍🍳',
+    accent: 'var(--color-coral-400)',
+  },
+  ramsay: {
+    key: 'ramsay',
+    name: 'Xomdon Ramsay',
+    caption: "It's RAW.",
+    emoji: '😤',
+    accent: 'var(--color-flame-500)',
+  },
+  fieri: {
+    key: 'fieri',
+    name: 'Xom Fieri',
+    caption: 'Welcome to Flavortown.',
+    emoji: '🔥',
+    accent: '#ffd166',
+  },
+};
+
+interface Props {
+  mascot: MascotKey;
+  size?: 'sm' | 'md' | 'lg';
+}
+
+const SIZE = {
+  sm: { box: 'h-8 w-8 text-base', label: 'text-xs' },
+  md: { box: 'h-12 w-12 text-2xl', label: 'text-sm' },
+  lg: { box: 'h-20 w-20 text-4xl', label: 'text-base' },
+};
+
+export default function Mascot({ mascot, size = 'md' }: Props) {
+  const profile = MASCOTS[mascot];
+  const s = SIZE[size];
+  return (
+    <div className="flex items-center gap-2">
+      <div
+        className={`${s.box} rounded-full grid place-items-center bg-zinc-900 border-2`}
+        style={{ borderColor: profile.accent }}
+        aria-hidden="true"
+      >
+        <span>{profile.emoji}</span>
+      </div>
+      <div className={s.label}>
+        <div className="font-semibold leading-tight">{profile.name}</div>
+        <div className="text-zinc-400 leading-tight">{profile.caption}</div>
+      </div>
+    </div>
+  );
+}
+
+/** Pick a mascot for a given context. Stable per (key) so the same meal
+ * always shows the same mascot until we wire user preference. */
+export function mascotFor(seed: string): MascotKey {
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) h = (h * 31 + seed.charCodeAt(i)) | 0;
+  const keys: MascotKey[] = ['boyardee', 'ramsay', 'fieri'];
+  return keys[Math.abs(h) % keys.length];
+}

--- a/src/components/MealCard.tsx
+++ b/src/components/MealCard.tsx
@@ -3,13 +3,18 @@ import { Meal } from '@/types';
 
 interface Props {
   meal: Meal;
+  onOpen: (meal: Meal) => void;
   onToggleCooked: (id: string) => void;
   onRate: (meal: Meal) => void;
   onDelete: (id: string) => void;
 }
 
 function diffColor(d: string) {
-  return d === 'Easy' ? 'text-green-400' : d === 'Medium' ? 'text-yellow-400' : 'text-red-400';
+  return d === 'Easy'
+    ? 'text-emerald-400'
+    : d === 'Medium'
+    ? 'text-amber-400'
+    : 'text-coral-400';
 }
 
 function avgRating(meal: Meal) {
@@ -18,43 +23,83 @@ function avgRating(meal: Meal) {
   return ((taste + ease + speed + healthiness) / 4).toFixed(1);
 }
 
-export default function MealCard({ meal, onToggleCooked, onRate, onDelete }: Props) {
+export default function MealCard({
+  meal,
+  onOpen,
+  onToggleCooked,
+  onRate,
+  onDelete,
+}: Props) {
   return (
-    <div className="bg-gray-900 border border-gray-700 rounded-xl p-4 space-y-3">
-      <div className="flex items-start justify-between">
-        <div>
-          <h3 className="font-semibold text-base">{meal.name}</h3>
-          <span className={`text-xs ${diffColor(meal.difficulty)}`}>{meal.difficulty}</span>
-          <span className="text-xs text-gray-400 ml-2">{meal.timeMinutes}min</span>
+    <div
+      onClick={() => onOpen(meal)}
+      className="group bg-zinc-900/60 border border-zinc-800 hover:border-coral-500/50 rounded-xl p-4 space-y-3 cursor-pointer transition hover:shadow-lg hover:shadow-coral-500/10"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <h3 className="font-bold text-base truncate group-hover:text-coral-300 transition">
+            {meal.name}
+          </h3>
+          <div className="text-xs flex items-center gap-1.5 mt-0.5">
+            <span className={`font-semibold ${diffColor(meal.difficulty)}`}>
+              {meal.difficulty}
+            </span>
+            <span className="text-zinc-700">·</span>
+            <span className="text-zinc-400">{meal.timeMinutes}m</span>
+          </div>
         </div>
-        <label className="flex items-center gap-1.5 cursor-pointer">
-          <input type="checkbox" checked={meal.cooked} onChange={() => onToggleCooked(meal.id)}
-            className="accent-green-500 w-4 h-4" />
-          <span className="text-xs text-gray-400">Cooked</span>
+        <label
+          className="flex items-center gap-1.5 cursor-pointer flex-shrink-0"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <input
+            type="checkbox"
+            checked={meal.cooked}
+            onChange={() => onToggleCooked(meal.id)}
+            className="accent-coral-400 w-4 h-4"
+          />
+          <span className="text-xs text-zinc-500">Cooked</span>
         </label>
       </div>
+
       {meal.proteinSource && (
-        <span className="inline-block bg-blue-900/50 text-blue-300 text-xs px-2 py-0.5 rounded-full">
+        <span className="inline-block bg-coral-500/15 text-coral-300 text-xs px-2 py-0.5 rounded-full">
           {meal.proteinSource}
         </span>
       )}
-      <div className="text-xs text-gray-400 grid grid-cols-4 gap-1">
+
+      <div className="text-xs text-zinc-500 grid grid-cols-4 gap-1">
         <span>{meal.macros.calories} cal</span>
         <span>{meal.macros.protein}g P</span>
         <span>{meal.macros.carbs}g C</span>
         <span>{meal.macros.fat}g F</span>
       </div>
+
       {meal.rating && (
-        <div className="text-xs text-gray-300">
-          ⭐ {avgRating(meal)} avg
-          {meal.rating.notes && <span className="text-gray-500 ml-2">"{meal.rating.notes}"</span>}
+        <div className="text-xs flex items-center gap-2">
+          <span className="chef-stamp text-base">{avgRating(meal)}/5</span>
+          {meal.rating.notes && (
+            <span className="text-zinc-500 italic truncate flex-1">
+              "{meal.rating.notes}"
+            </span>
+          )}
         </div>
       )}
-      <div className="flex gap-2 pt-1">
-        <button onClick={() => onRate(meal)} className="text-xs bg-gray-800 hover:bg-gray-700 px-3 py-1 rounded-lg transition">
+
+      <div
+        className="flex gap-2 pt-1 border-t border-zinc-800/60"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          onClick={() => onRate(meal)}
+          className="text-xs font-semibold uppercase tracking-wider bg-zinc-800 hover:bg-zinc-700 px-3 py-1 rounded-md transition"
+        >
           {meal.rating ? 'Re-rate' : 'Rate'}
         </button>
-        <button onClick={() => onDelete(meal.id)} className="text-xs text-red-400 hover:text-red-300 px-3 py-1 rounded-lg transition">
+        <button
+          onClick={() => onDelete(meal.id)}
+          className="text-xs text-zinc-600 hover:text-coral-400 px-2 py-1 rounded-md transition ml-auto"
+        >
           Delete
         </button>
       </div>

--- a/src/components/MealDetailModal.tsx
+++ b/src/components/MealDetailModal.tsx
@@ -1,0 +1,190 @@
+'use client';
+import Modal from './Modal';
+import CommentsSection from './CommentsSection';
+import { Ingredient, Meal } from '@/types';
+import { ingredientLabel } from '@/types';
+import { mascotFor, MASCOTS } from './Mascot';
+
+interface Props {
+  open: boolean;
+  meal: Meal | null;
+  onClose: () => void;
+  onEdit: (meal: Meal) => void;
+  onRate: (meal: Meal) => void;
+  onToggleCooked: (id: string) => void;
+}
+
+function diffColor(d: string) {
+  return d === 'Easy'
+    ? 'text-emerald-400'
+    : d === 'Medium'
+    ? 'text-amber-400'
+    : 'text-coral-400';
+}
+
+function avgRating(meal: Meal) {
+  if (!meal.rating) return null;
+  const { taste, ease, speed, healthiness } = meal.rating;
+  return ((taste + ease + speed + healthiness) / 4).toFixed(1);
+}
+
+export default function MealDetailModal({
+  open,
+  meal,
+  onClose,
+  onEdit,
+  onRate,
+  onToggleCooked,
+}: Props) {
+  if (!meal) return null;
+
+  const mascot = MASCOTS[mascotFor(meal.id)];
+  const ingredients = (meal.ingredients ?? []) as (string | Ingredient)[];
+  const instructions = meal.instructions ?? [];
+
+  return (
+    <Modal open={open} onClose={onClose} title={meal.name}>
+      <div className="space-y-5">
+        {/* Top facts strip */}
+        <div className="flex flex-wrap items-center gap-2 text-xs">
+          <span className={`font-semibold ${diffColor(meal.difficulty)}`}>
+            {meal.difficulty}
+          </span>
+          <span className="text-zinc-600">·</span>
+          <span className="text-zinc-300">{meal.timeMinutes} min</span>
+          {meal.proteinSource && (
+            <>
+              <span className="text-zinc-600">·</span>
+              <span className="bg-coral-500/15 text-coral-300 px-2 py-0.5 rounded-full">
+                {meal.proteinSource}
+              </span>
+            </>
+          )}
+          <span className="text-zinc-600">·</span>
+          <button
+            onClick={() => onToggleCooked(meal.id)}
+            className={`px-2 py-0.5 rounded-full font-semibold transition ${
+              meal.cooked
+                ? 'bg-emerald-500/15 text-emerald-300 hover:bg-emerald-500/25'
+                : 'bg-zinc-800 text-zinc-400 hover:bg-zinc-700'
+            }`}
+          >
+            {meal.cooked ? '✓ Cooked' : '○ Not yet'}
+          </button>
+        </div>
+
+        {/* Macros */}
+        <div className="grid grid-cols-4 gap-2 bg-zinc-900/60 border border-zinc-800 rounded-lg p-3">
+          {[
+            ['Cal', meal.macros.calories],
+            ['Protein', `${meal.macros.protein}g`],
+            ['Carbs', `${meal.macros.carbs}g`],
+            ['Fat', `${meal.macros.fat}g`],
+          ].map(([label, val]) => (
+            <div key={label as string} className="text-center">
+              <div className="text-[10px] uppercase tracking-wider text-zinc-500">
+                {label}
+              </div>
+              <div className="font-bold text-base mt-0.5">{val}</div>
+            </div>
+          ))}
+        </div>
+
+        {/* Rating */}
+        {meal.rating ? (
+          <div className="bg-zinc-900/60 border border-zinc-800 rounded-lg p-3">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-xs uppercase tracking-wider text-zinc-400 font-semibold">
+                {mascot.name} says
+              </span>
+              <span className="chef-stamp text-lg">{avgRating(meal)} / 5</span>
+            </div>
+            <div className="grid grid-cols-4 gap-2 text-xs">
+              {[
+                ['Taste', meal.rating.taste],
+                ['Ease', meal.rating.ease],
+                ['Speed', meal.rating.speed],
+                ['Health', meal.rating.healthiness],
+              ].map(([k, v]) => (
+                <div key={k as string} className="text-center">
+                  <div className="text-zinc-500">{k}</div>
+                  <div className="font-bold">{v}</div>
+                </div>
+              ))}
+            </div>
+            {meal.rating.notes && (
+              <div className="mt-2 text-sm text-zinc-300 italic">
+                "{meal.rating.notes}"
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="border border-dashed border-zinc-800 rounded-lg p-3 text-sm text-zinc-500 italic">
+            Not rated yet. {mascot.caption}
+          </div>
+        )}
+
+        {/* Ingredients */}
+        <div>
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-400 mb-2">
+            Ingredients
+          </h3>
+          {ingredients.length === 0 ? (
+            <div className="text-sm text-zinc-500 italic">No ingredients listed.</div>
+          ) : (
+            <ul className="space-y-1">
+              {ingredients.map((ing, i) => (
+                <li key={i} className="text-sm text-zinc-200 flex items-baseline gap-2">
+                  <span className="w-1.5 h-1.5 rounded-full bg-coral-400 flex-shrink-0 mt-1.5" />
+                  {ingredientLabel(ing)}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {/* Instructions */}
+        <div>
+          <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-400 mb-2">
+            How to cook
+          </h3>
+          {instructions.length === 0 ? (
+            <div className="text-sm text-zinc-500 italic">No instructions yet.</div>
+          ) : (
+            <ol className="space-y-2">
+              {instructions.map((step, i) => (
+                <li key={i} className="flex items-start gap-3 text-sm">
+                  <span className="w-6 h-6 rounded-full bg-coral-500/20 text-coral-400 text-xs grid place-items-center font-bold flex-shrink-0 mt-0.5">
+                    {i + 1}
+                  </span>
+                  <span className="text-zinc-200 leading-relaxed">{step}</span>
+                </li>
+              ))}
+            </ol>
+          )}
+        </div>
+
+        {/* Comments */}
+        <div className="pt-2 border-t border-zinc-800">
+          <CommentsSection mealId={meal.id} />
+        </div>
+
+        {/* Actions */}
+        <div className="flex gap-2 pt-2 border-t border-zinc-800">
+          <button
+            onClick={() => onEdit(meal)}
+            className="flex-1 bg-zinc-800 hover:bg-zinc-700 text-sm font-semibold uppercase tracking-wider py-2 rounded-lg transition"
+          >
+            Edit
+          </button>
+          <button
+            onClick={() => onRate(meal)}
+            className="flex-1 bg-gradient-to-r from-coral-500 to-coral-400 hover:from-coral-400 hover:to-coral-300 text-white text-sm font-bold uppercase tracking-wider py-2 rounded-lg transition shadow-lg shadow-coral-500/20"
+          >
+            {meal.rating ? 'Re-rate' : 'Rate'}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/components/MealForm.tsx
+++ b/src/components/MealForm.tsx
@@ -1,0 +1,174 @@
+'use client';
+import { useState } from 'react';
+import { Ingredient, Meal } from '@/types';
+import IngredientsEditor from './IngredientsEditor';
+import InstructionsEditor from './InstructionsEditor';
+
+const DIFFICULTIES = ['Easy', 'Medium', 'Hard'] as const;
+type Difficulty = (typeof DIFFICULTIES)[number];
+
+export interface MealFormValues {
+  name: string;
+  timeMinutes: number;
+  difficulty: Difficulty;
+  proteinSource: string;
+  ingredients: Ingredient[];
+  instructions: string[];
+  macros: { calories: number; protein: number; carbs: number; fat: number };
+}
+
+interface Props {
+  initial?: Partial<MealFormValues> | Meal;
+  submitLabel: string;
+  onSubmit: (values: MealFormValues) => Promise<void>;
+}
+
+const inputCls =
+  'w-full bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-coral-400 focus:border-transparent';
+const labelCls = 'block text-xs font-semibold uppercase tracking-wider text-zinc-400 mb-1.5';
+
+function normalizeIngredient(i: string | Ingredient): Ingredient {
+  if (typeof i === 'string') return { name: i, quantity: null, unit: null };
+  return i;
+}
+
+export default function MealForm({ initial, submitLabel, onSubmit }: Props) {
+  const seed = initial ?? {};
+  const [name, setName] = useState(seed.name ?? '');
+  const [timeMinutes, setTimeMinutes] = useState(seed.timeMinutes ?? 30);
+  const [difficulty, setDifficulty] = useState<Difficulty>(
+    (seed.difficulty as Difficulty) ?? 'Medium'
+  );
+  const [proteinSource, setProteinSource] = useState(seed.proteinSource ?? '');
+  const [ingredients, setIngredients] = useState<Ingredient[]>(
+    (seed.ingredients ?? []).map(normalizeIngredient)
+  );
+  const [instructions, setInstructions] = useState<string[]>(seed.instructions ?? []);
+  const [calories, setCalories] = useState(seed.macros?.calories ?? 0);
+  const [protein, setProtein] = useState(seed.macros?.protein ?? 0);
+  const [carbs, setCarbs] = useState(seed.macros?.carbs ?? 0);
+  const [fat, setFat] = useState(seed.macros?.fat ?? 0);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onSubmit({
+        name: name.trim(),
+        timeMinutes,
+        difficulty,
+        proteinSource,
+        ingredients: ingredients.filter((i) => i.name.trim()),
+        instructions: instructions.filter((s) => s.trim()),
+        macros: { calories, protein, carbs, fat },
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5">
+      <div>
+        <label className={labelCls}>Name *</label>
+        <input
+          className={inputCls}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Chicken Stir Fry"
+          required
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label className={labelCls}>Time (min)</label>
+          <input
+            type="number"
+            className={inputCls}
+            value={timeMinutes}
+            onChange={(e) => setTimeMinutes(+e.target.value)}
+            min={1}
+          />
+        </div>
+        <div>
+          <label className={labelCls}>Difficulty</label>
+          <select
+            className={inputCls}
+            value={difficulty}
+            onChange={(e) => setDifficulty(e.target.value as Difficulty)}
+          >
+            {DIFFICULTIES.map((d) => (
+              <option key={d}>{d}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div>
+        <label className={labelCls}>Protein source</label>
+        <input
+          className={inputCls}
+          value={proteinSource}
+          onChange={(e) => setProteinSource(e.target.value)}
+          placeholder="Chicken, Tofu, Beef…"
+        />
+      </div>
+
+      <div>
+        <label className={labelCls}>Ingredients</label>
+        <IngredientsEditor ingredients={ingredients} onChange={setIngredients} />
+      </div>
+
+      <div>
+        <label className={labelCls}>Instructions</label>
+        <InstructionsEditor steps={instructions} onChange={setInstructions} />
+      </div>
+
+      <div>
+        <label className={labelCls}>Macros</label>
+        <div className="grid grid-cols-4 gap-2">
+          {([
+            ['Cal', calories, setCalories],
+            ['Protein', protein, setProtein],
+            ['Carbs', carbs, setCarbs],
+            ['Fat', fat, setFat],
+          ] as const).map(([label, val, setter]) => (
+            <div key={label}>
+              <span className="text-[10px] uppercase tracking-wider text-zinc-500">
+                {label}
+              </span>
+              <input
+                type="number"
+                className={inputCls}
+                value={val}
+                onChange={(e) => setter(+e.target.value)}
+                min={0}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {error && (
+        <div className="text-xs text-coral-300 bg-coral-900/30 border border-coral-800 rounded-md px-3 py-2">
+          {error}
+        </div>
+      )}
+
+      <button
+        type="submit"
+        disabled={submitting || !name.trim()}
+        className="w-full bg-gradient-to-r from-coral-500 to-coral-400 hover:from-coral-400 hover:to-coral-300 disabled:opacity-40 disabled:cursor-not-allowed text-white font-bold uppercase tracking-wider py-2.5 px-4 rounded-lg transition shadow-lg shadow-coral-500/20"
+      >
+        {submitting ? 'Saving…' : submitLabel}
+      </button>
+    </form>
+  );
+}

--- a/src/components/MealTable.tsx
+++ b/src/components/MealTable.tsx
@@ -3,54 +3,91 @@ import { Meal } from '@/types';
 
 interface Props {
   meals: Meal[];
+  onOpen: (meal: Meal) => void;
   onToggleCooked: (id: string) => void;
   onRate: (meal: Meal) => void;
   onDelete: (id: string) => void;
 }
 
 function diffColor(d: string) {
-  return d === 'Easy' ? 'text-green-400' : d === 'Medium' ? 'text-yellow-400' : 'text-red-400';
+  return d === 'Easy'
+    ? 'text-emerald-400'
+    : d === 'Medium'
+    ? 'text-amber-400'
+    : 'text-coral-400';
 }
 
-export default function MealTable({ meals, onToggleCooked, onRate, onDelete }: Props) {
+export default function MealTable({
+  meals,
+  onOpen,
+  onToggleCooked,
+  onRate,
+  onDelete,
+}: Props) {
   return (
-    <div className="overflow-x-auto">
+    <div className="overflow-x-auto rounded-xl border border-zinc-800">
       <table className="w-full text-sm">
-        <thead>
-          <tr className="border-b border-gray-700 text-gray-400 text-left">
-            <th className="py-3 px-3">Cooked</th>
+        <thead className="bg-zinc-900/60">
+          <tr className="text-zinc-500 text-xs uppercase tracking-wider text-left">
+            <th className="py-3 px-3 w-10">✓</th>
             <th className="py-3 px-3">Name</th>
             <th className="py-3 px-3">Protein</th>
-            <th className="py-3 px-3">Difficulty</th>
+            <th className="py-3 px-3">Diff.</th>
             <th className="py-3 px-3">Time</th>
-            <th className="py-3 px-3">Calories</th>
+            <th className="py-3 px-3">Cal</th>
             <th className="py-3 px-3">Rating</th>
-            <th className="py-3 px-3">Actions</th>
+            <th className="py-3 px-3 w-20"></th>
           </tr>
         </thead>
         <tbody>
-          {meals.map(meal => (
-            <tr key={meal.id} className="border-b border-gray-800 hover:bg-gray-900/50">
-              <td className="py-3 px-3">
-                <input type="checkbox" checked={meal.cooked} onChange={() => onToggleCooked(meal.id)}
-                  className="accent-green-500 w-4 h-4 cursor-pointer" />
+          {meals.map((meal) => (
+            <tr
+              key={meal.id}
+              onClick={() => onOpen(meal)}
+              className="border-t border-zinc-800 hover:bg-zinc-900/60 cursor-pointer transition"
+            >
+              <td className="py-3 px-3" onClick={(e) => e.stopPropagation()}>
+                <input
+                  type="checkbox"
+                  checked={meal.cooked}
+                  onChange={() => onToggleCooked(meal.id)}
+                  className="accent-coral-400 w-4 h-4 cursor-pointer"
+                />
               </td>
-              <td className="py-3 px-3 font-medium">{meal.name}</td>
-              <td className="py-3 px-3 text-gray-400">{meal.proteinSource || '—'}</td>
-              <td className={`py-3 px-3 ${diffColor(meal.difficulty)}`}>{meal.difficulty}</td>
-              <td className="py-3 px-3 text-gray-400">{meal.timeMinutes}m</td>
-              <td className="py-3 px-3 text-gray-400">{meal.macros.calories}</td>
-              <td className="py-3 px-3">
-                {meal.rating
-                  ? <span className="text-yellow-400">⭐ {((meal.rating.taste + meal.rating.ease + meal.rating.speed + meal.rating.healthiness) / 4).toFixed(1)}</span>
-                  : <span className="text-gray-600">—</span>}
+              <td className="py-3 px-3 font-semibold">{meal.name}</td>
+              <td className="py-3 px-3 text-zinc-400">{meal.proteinSource || '—'}</td>
+              <td className={`py-3 px-3 font-semibold ${diffColor(meal.difficulty)}`}>
+                {meal.difficulty}
               </td>
+              <td className="py-3 px-3 text-zinc-400">{meal.timeMinutes}m</td>
+              <td className="py-3 px-3 text-zinc-400">{meal.macros.calories}</td>
               <td className="py-3 px-3">
-                <div className="flex gap-2">
-                  <button onClick={() => onRate(meal)} className="text-blue-400 hover:text-blue-300 text-xs">
+                {meal.rating ? (
+                  <span className="chef-stamp font-bold">
+                    {(
+                      (meal.rating.taste +
+                        meal.rating.ease +
+                        meal.rating.speed +
+                        meal.rating.healthiness) /
+                      4
+                    ).toFixed(1)}
+                  </span>
+                ) : (
+                  <span className="text-zinc-700">—</span>
+                )}
+              </td>
+              <td className="py-3 px-3" onClick={(e) => e.stopPropagation()}>
+                <div className="flex gap-2 justify-end">
+                  <button
+                    onClick={() => onRate(meal)}
+                    className="text-coral-300 hover:text-coral-200 text-xs font-semibold uppercase tracking-wider"
+                  >
                     {meal.rating ? 'Re-rate' : 'Rate'}
                   </button>
-                  <button onClick={() => onDelete(meal.id)} className="text-red-400 hover:text-red-300 text-xs">
+                  <button
+                    onClick={() => onDelete(meal.id)}
+                    className="text-zinc-600 hover:text-coral-400 text-xs"
+                  >
                     Del
                   </button>
                 </div>
@@ -60,7 +97,9 @@ export default function MealTable({ meals, onToggleCooked, onRate, onDelete }: P
         </tbody>
       </table>
       {meals.length === 0 && (
-        <div className="text-center text-gray-500 py-12">No meals found. Add one to get started!</div>
+        <div className="text-center text-zinc-500 py-12 italic">
+          No meals match. Loosen the filters or log a new one.
+        </div>
       )}
     </div>
   );

--- a/src/components/RateMealModal.tsx
+++ b/src/components/RateMealModal.tsx
@@ -1,7 +1,8 @@
 'use client';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Modal from './Modal';
 import { Meal, MealRating } from '@/types';
+import { mascotFor, MASCOTS } from './Mascot';
 
 interface Props {
   open: boolean;
@@ -10,58 +11,120 @@ interface Props {
   onRate: (id: string, rating: MealRating) => Promise<void>;
 }
 
-function Slider({ label, value, onChange }: { label: string; value: number; onChange: (v: number) => void }) {
+function StarPicker({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  onChange: (v: number) => void;
+}) {
   return (
     <div>
-      <div className="flex justify-between text-sm mb-1">
-        <span className="text-gray-300">{label}</span>
-        <span className="text-blue-400 font-mono">{value}/10</span>
+      <div className="flex items-center justify-between mb-1.5">
+        <span className="text-xs font-semibold uppercase tracking-wider text-zinc-400">
+          {label}
+        </span>
+        <span className="chef-stamp text-base">{value}/5</span>
       </div>
-      <input
-        type="range" min={1} max={10} value={value} onChange={e => onChange(+e.target.value)}
-        className="w-full accent-blue-500"
-      />
+      <div className="flex gap-1.5">
+        {[1, 2, 3, 4, 5].map((n) => (
+          <button
+            key={n}
+            type="button"
+            onClick={() => onChange(n)}
+            className={`flex-1 py-2 rounded-md text-base font-bold transition ${
+              n <= value
+                ? 'bg-gradient-to-br from-coral-500 to-coral-400 text-white shadow-md shadow-coral-500/30'
+                : 'bg-zinc-900 border border-zinc-700 text-zinc-600 hover:text-zinc-400 hover:border-zinc-600'
+            }`}
+            aria-label={`${label} ${n} of 5`}
+          >
+            {n}
+          </button>
+        ))}
+      </div>
     </div>
   );
 }
 
 export default function RateMealModal({ open, meal, onClose, onRate }: Props) {
-  const [taste, setTaste] = useState(meal?.rating?.taste ?? 5);
-  const [ease, setEase] = useState(meal?.rating?.ease ?? 5);
-  const [speed, setSpeed] = useState(meal?.rating?.speed ?? 5);
-  const [healthiness, setHealthiness] = useState(meal?.rating?.healthiness ?? 5);
-  const [notes, setNotes] = useState(meal?.rating?.notes ?? '');
+  const [taste, setTaste] = useState(3);
+  const [ease, setEase] = useState(3);
+  const [speed, setSpeed] = useState(3);
+  const [healthiness, setHealthiness] = useState(3);
+  const [notes, setNotes] = useState('');
   const [submitting, setSubmitting] = useState(false);
+
+  // Reset state to current meal's rating when modal opens
+  useEffect(() => {
+    if (!open || !meal) return;
+    setTaste(meal.rating?.taste ?? 3);
+    setEase(meal.rating?.ease ?? 3);
+    setSpeed(meal.rating?.speed ?? 3);
+    setHealthiness(meal.rating?.healthiness ?? 3);
+    setNotes(meal.rating?.notes ?? '');
+  }, [open, meal]);
+
+  if (!meal) return null;
+
+  const mascot = MASCOTS[mascotFor(meal.id)];
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!meal) return;
     setSubmitting(true);
-    await onRate(meal.id, { taste, ease, speed, healthiness, notes });
-    setSubmitting(false);
-    onClose();
+    try {
+      await onRate(meal.id, { taste, ease, speed, healthiness, notes });
+      onClose();
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (
-    <Modal open={open} onClose={onClose} title={`Rate: ${meal?.name ?? ''}`}>
+    <Modal open={open} onClose={onClose} title={`Rate: ${meal.name}`}>
       <form onSubmit={handleSubmit} className="space-y-4">
-        <Slider label="Taste" value={taste} onChange={setTaste} />
-        <Slider label="Ease" value={ease} onChange={setEase} />
-        <Slider label="Speed" value={speed} onChange={setSpeed} />
-        <Slider label="Healthiness" value={healthiness} onChange={setHealthiness} />
+        <div className="bg-zinc-900/60 border border-zinc-800 rounded-lg p-3 flex items-center gap-3">
+          <span
+            className="h-9 w-9 rounded-full grid place-items-center text-xl flex-shrink-0"
+            style={{
+              background: `${mascot.accent}22`,
+              border: `1px solid ${mascot.accent}66`,
+            }}
+            aria-hidden="true"
+          >
+            {mascot.emoji}
+          </span>
+          <div className="text-sm">
+            <div className="font-semibold text-zinc-200">{mascot.name} is judging.</div>
+            <div className="text-zinc-500 text-xs italic">"{mascot.caption}"</div>
+          </div>
+        </div>
+
+        <StarPicker label="Taste" value={taste} onChange={setTaste} />
+        <StarPicker label="Ease" value={ease} onChange={setEase} />
+        <StarPicker label="Speed" value={speed} onChange={setSpeed} />
+        <StarPicker label="Healthiness" value={healthiness} onChange={setHealthiness} />
+
         <div>
-          <label className="block text-sm font-medium text-gray-300 mb-1">Notes</label>
+          <label className="block text-xs font-semibold uppercase tracking-wider text-zinc-400 mb-1.5">
+            Notes
+          </label>
           <textarea
-            className="w-full bg-gray-800 border border-gray-600 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 h-20"
-            value={notes} onChange={e => setNotes(e.target.value)}
+            className="w-full bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-coral-400 focus:border-transparent h-20"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            placeholder="What worked? What flopped?"
           />
         </div>
+
         <button
           type="submit"
           disabled={submitting}
-          className="w-full bg-green-600 hover:bg-green-700 disabled:opacity-50 text-white font-medium py-2 px-4 rounded-lg transition"
+          className="w-full bg-gradient-to-r from-coral-500 to-coral-400 hover:from-coral-400 hover:to-coral-300 disabled:opacity-40 text-white font-bold uppercase tracking-wider py-2.5 px-4 rounded-lg transition shadow-lg shadow-coral-500/20"
         >
-          {submitting ? 'Saving...' : 'Save Rating'}
+          {submitting ? 'Saving…' : 'Save rating'}
         </button>
       </form>
     </Modal>

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -1,8 +1,11 @@
 import useSWR, { mutate } from 'swr';
-import { mealsApi } from './storage';
+import { mealsApi, commentsApi } from './storage';
 import { Meal, MealRating } from '@/types';
 
 const MEALS_KEY = 'meals';
+const commentsKey = (mealId: string) => ['comments', mealId] as const;
+
+type EditableMealFields = Parameters<typeof mealsApi.edit>[1];
 
 export function useMeals() {
   const { data, error, isLoading } = useSWR(MEALS_KEY, mealsApi.getAll);
@@ -13,6 +16,10 @@ export function useMeals() {
     error,
     addMeal: async (meal: Omit<Meal, 'id' | 'createdAt' | 'cooked'>) => {
       await mealsApi.add(meal);
+      mutate(MEALS_KEY);
+    },
+    editMeal: async (id: string, fields: EditableMealFields) => {
+      await mealsApi.edit(id, fields);
       mutate(MEALS_KEY);
     },
     toggleCooked: async (id: string) => {
@@ -26,6 +33,29 @@ export function useMeals() {
     deleteMeal: async (id: string) => {
       await mealsApi.delete(id);
       mutate(MEALS_KEY);
+    },
+  };
+}
+
+export function useMealComments(mealId: string | null) {
+  const key = mealId ? commentsKey(mealId) : null;
+  const { data, error, isLoading } = useSWR(key, () =>
+    mealId ? commentsApi.list(mealId) : Promise.resolve([])
+  );
+
+  return {
+    comments: data ?? [],
+    isLoading,
+    error,
+    addComment: async (body: string) => {
+      if (!mealId) return;
+      await commentsApi.add(mealId, body);
+      mutate(commentsKey(mealId));
+    },
+    deleteComment: async (commentId: string) => {
+      if (!mealId) return;
+      await commentsApi.delete(mealId, commentId);
+      mutate(commentsKey(mealId));
     },
   };
 }

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,22 +1,36 @@
 import { Meal, MealRating, MealComment } from '@/types';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'https://api.xomware.com';
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'https://api.xomappetit.xomware.com';
 const AUTH_HASH = process.env.NEXT_PUBLIC_AUTH_HASH || '';
 
-async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
-  const res = await fetch(`${API_BASE}/meals${path}`, {
-    ...options,
+async function apiPost<T>(verb: string, body?: unknown): Promise<T> {
+  const res = await fetch(`${API_BASE}/meals/${verb}`, {
+    method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       'X-Auth-Hash': AUTH_HASH,
-      ...options?.headers,
+    },
+    body: body == null ? undefined : JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`API error ${res.status}: ${text}`);
+  }
+  if (res.status === 204) return undefined as T;
+  return res.json();
+}
+
+async function apiGet<T>(verb: string): Promise<T> {
+  const res = await fetch(`${API_BASE}/meals/${verb}`, {
+    method: 'GET',
+    headers: {
+      'X-Auth-Hash': AUTH_HASH,
     },
   });
   if (!res.ok) {
-    const body = await res.text().catch(() => '');
-    throw new Error(`API error ${res.status}: ${body}`);
+    const text = await res.text().catch(() => '');
+    throw new Error(`API error ${res.status}: ${text}`);
   }
-  if (res.status === 204) return undefined as T;
   return res.json();
 }
 
@@ -28,49 +42,33 @@ type EditableMealFields = Partial<
 >;
 
 export const mealsApi = {
-  getAll: async (): Promise<Meal[]> => apiFetch<Meal[]>(''),
+  getAll: async (): Promise<Meal[]> => apiGet<Meal[]>('list'),
 
   add: async (meal: Omit<Meal, 'id' | 'createdAt' | 'cooked'>): Promise<Meal> =>
-    apiFetch<Meal>('', {
-      method: 'POST',
-      body: JSON.stringify(meal),
-    }),
+    apiPost<Meal>('create', meal),
+
+  get: async (id: string): Promise<Meal> => apiPost<Meal>('get', { id }),
 
   edit: async (id: string, fields: EditableMealFields): Promise<Meal> =>
-    apiFetch<Meal>(`/${id}`, {
-      method: 'PATCH',
-      body: JSON.stringify(fields),
-    }),
+    apiPost<Meal>('edit', { id, ...fields }),
 
   toggleCooked: async (id: string): Promise<Meal> =>
-    apiFetch<Meal>(`/${id}/toggle-cooked`, {
-      method: 'PATCH',
-    }),
+    apiPost<Meal>('update', { id }),
 
   rate: async (id: string, rating: MealRating): Promise<Meal> =>
-    apiFetch<Meal>(`/${id}/rate`, {
-      method: 'PATCH',
-      body: JSON.stringify(rating),
-    }),
+    apiPost<Meal>('rate', { id, ...rating }),
 
   delete: async (id: string): Promise<void> =>
-    apiFetch<void>(`/${id}`, {
-      method: 'DELETE',
-    }),
+    apiPost<void>('delete', { id }),
 };
 
 export const commentsApi = {
   list: async (mealId: string): Promise<MealComment[]> =>
-    apiFetch<MealComment[]>(`/${mealId}/comments`),
+    apiPost<MealComment[]>('comments-list', { mealId }),
 
   add: async (mealId: string, body: string): Promise<MealComment> =>
-    apiFetch<MealComment>(`/${mealId}/comments`, {
-      method: 'POST',
-      body: JSON.stringify({ body }),
-    }),
+    apiPost<MealComment>('comment-add', { mealId, body }),
 
   delete: async (mealId: string, commentId: string): Promise<void> =>
-    apiFetch<void>(`/${mealId}/comments/${commentId}`, {
-      method: 'DELETE',
-    }),
+    apiPost<void>('comment-delete', { mealId, commentId }),
 };

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,4 +1,4 @@
-import { Meal, MealRating } from '@/types';
+import { Meal, MealRating, MealComment } from '@/types';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'https://api.xomware.com';
 const AUTH_HASH = process.env.NEXT_PUBLIC_AUTH_HASH || '';
@@ -16,10 +16,16 @@ async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
     const body = await res.text().catch(() => '');
     throw new Error(`API error ${res.status}: ${body}`);
   }
-  // DELETE may return 204
   if (res.status === 204) return undefined as T;
   return res.json();
 }
+
+type EditableMealFields = Partial<
+  Pick<
+    Meal,
+    'name' | 'timeMinutes' | 'difficulty' | 'proteinSource' | 'ingredients' | 'instructions' | 'macros'
+  >
+>;
 
 export const mealsApi = {
   getAll: async (): Promise<Meal[]> => apiFetch<Meal[]>(''),
@@ -28,6 +34,12 @@ export const mealsApi = {
     apiFetch<Meal>('', {
       method: 'POST',
       body: JSON.stringify(meal),
+    }),
+
+  edit: async (id: string, fields: EditableMealFields): Promise<Meal> =>
+    apiFetch<Meal>(`/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(fields),
     }),
 
   toggleCooked: async (id: string): Promise<Meal> =>
@@ -43,6 +55,22 @@ export const mealsApi = {
 
   delete: async (id: string): Promise<void> =>
     apiFetch<void>(`/${id}`, {
+      method: 'DELETE',
+    }),
+};
+
+export const commentsApi = {
+  list: async (mealId: string): Promise<MealComment[]> =>
+    apiFetch<MealComment[]>(`/${mealId}/comments`),
+
+  add: async (mealId: string, body: string): Promise<MealComment> =>
+    apiFetch<MealComment>(`/${mealId}/comments`, {
+      method: 'POST',
+      body: JSON.stringify({ body }),
+    }),
+
+  delete: async (mealId: string, commentId: string): Promise<void> =>
+    apiFetch<void>(`/${mealId}/comments/${commentId}`, {
       method: 'DELETE',
     }),
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,17 @@
+export interface Ingredient {
+  name: string;
+  quantity: number | null;
+  unit: string | null;
+}
+
 export interface Meal {
   id: string;
   name: string;
   timeMinutes: number;
   difficulty: 'Easy' | 'Medium' | 'Hard';
   proteinSource: string;
-  ingredients: string[];
+  ingredients: (string | Ingredient)[];
+  instructions?: string[];
   macros: {
     calories: number;
     protein: number;
@@ -17,11 +24,19 @@ export interface Meal {
 }
 
 export interface MealRating {
-  taste: number;      // 1-10
-  ease: number;       // 1-10
-  speed: number;      // 1-10
-  healthiness: number; // 1-10
+  taste: number;
+  ease: number;
+  speed: number;
+  healthiness: number;
   notes: string;
+}
+
+export interface MealComment {
+  mealId: string;
+  commentId: string;
+  userId: string;
+  body: string;
+  createdAt: string;
 }
 
 export type ViewMode = 'table' | 'card';
@@ -29,7 +44,19 @@ export type ViewMode = 'table' | 'card';
 export interface Filters {
   proteinSource: string;
   difficulty: string;
-  cookedStatus: string; // 'all' | 'cooked' | 'uncooked'
+  cookedStatus: string;
   timeMin: number;
   timeMax: number;
 }
+
+export const ingredientName = (i: string | Ingredient): string =>
+  typeof i === 'string' ? i : i.name;
+
+export const ingredientLabel = (i: string | Ingredient): string => {
+  if (typeof i === 'string') return i;
+  const parts: string[] = [];
+  if (i.quantity != null) parts.push(String(i.quantity));
+  if (i.unit) parts.push(i.unit);
+  parts.push(i.name);
+  return parts.join(' ');
+};


### PR DESCRIPTION
## Summary
- Adds `Ingredient` and `MealComment` types
- Widens `Meal.ingredients` to `(string | Ingredient)[]` so legacy string-only ingredients still type-check while new structured ingredients work
- Adds optional `Meal.instructions: string[]`
- Adds `mealsApi.edit(id, fields)` and `commentsApi.{list,add,delete}` to storage.ts
- Adds `useMealComments(mealId)` SWR hook + `editMeal` to `useMeals`

## Out of scope
- UI components are intentionally untouched — designing forms/displays for instructions, structured ingredients, and a comment thread is a separate visual design pass
- AddMealModal continues to send ingredients as a flat string list; the backend normalizes them. UI redesign comes later.

## Blocked on infra
- API methods will fail until \`meals-infrastructure\` provisions the new lambdas (\`meals-edit\`, \`meals-comment-add\`, \`meals-comments-list\`, \`meals-comment-delete\`) and the \`meal-comments\` DynamoDB table. Tracked under the Xom Appetite rollout epic.

## Companion PR
- Backend: Xomware/meals-backend#8

## Test plan
- [x] \`tsc --noEmit\` passes
- [ ] End-to-end test once backend infra is deployed
- [ ] UI redesign (separate PR)