### PR TITLE
Phase 3 (frontend): profile page + edit + avatar upload

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -44,6 +44,8 @@ jobs:
             echo "NEXT_PUBLIC_COGNITO_USER_POOL_ID=$(aws ssm get-parameter --name /xomware/shared/cognito/user-pool-id --query Parameter.Value --output text)"
             echo "NEXT_PUBLIC_COGNITO_CLIENT_ID=$(aws ssm get-parameter --name /xomware/shared/cognito/clients/xomappetit-id --query Parameter.Value --output text)"
             echo "NEXT_PUBLIC_COGNITO_DOMAIN=$(aws ssm get-parameter --name /xomware/shared/cognito/hosted-ui-domain --query Parameter.Value --output text)"
+            echo "NEXT_PUBLIC_USERS_API_URL=$(aws ssm get-parameter --name /xomware/shared/users-api/url --query Parameter.Value --output text)"
+            echo "NEXT_PUBLIC_AVATARS_CDN_URL=$(aws ssm get-parameter --name /xomware/shared/avatars/cdn-url --query Parameter.Value --output text)"
           } >> "$GITHUB_ENV"
 
       - name: Build (Next.js static export)

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,259 @@
+'use client';
+import { useState } from 'react';
+import Link from 'next/link';
+import { useRequireAuth } from '@/lib/auth-context';
+import { useProfile } from '@/lib/use-profile';
+import EditProfileModal from '@/components/EditProfileModal';
+import { UserProfile } from '@/lib/users';
+
+export default function ProfilePage() {
+  const { isAuthenticated, isLoading: authLoading } = useRequireAuth();
+  const { profile, isLoading, error, edit, uploadAvatar } = useProfile();
+  const [editOpen, setEditOpen] = useState(false);
+
+  if (authLoading || !isAuthenticated) {
+    return <ProfileLoading />;
+  }
+
+  if (isLoading) {
+    return <ProfileLoading />;
+  }
+
+  if (error || !profile) {
+    return <ProfileError message={error?.message ?? 'Profile unavailable'} />;
+  }
+
+  return (
+    <div className="min-h-screen bg-zinc-950">
+      <ProfileHeader />
+      <main className="max-w-3xl mx-auto px-4 py-8 sm:py-12">
+        <ProfileCard
+          profile={profile}
+          onEdit={() => setEditOpen(true)}
+          onUploadAvatar={uploadAvatar}
+        />
+        <StatsGrid />
+      </main>
+      <EditProfileModal
+        open={editOpen}
+        profile={profile}
+        onClose={() => setEditOpen(false)}
+        onSave={edit}
+        onUploadAvatar={uploadAvatar}
+      />
+    </div>
+  );
+}
+
+function ProfileHeader() {
+  return (
+    <header className="border-b border-zinc-800 bg-gradient-to-b from-zinc-950 to-zinc-950/80 backdrop-blur sticky top-0 z-30">
+      <div className="max-w-3xl mx-auto px-4 py-4 flex items-center justify-between gap-4">
+        <Link href="/" className="group inline-flex items-center gap-2">
+          <span className="text-zinc-500 group-hover:text-coral-300 transition text-lg">
+            ←
+          </span>
+          <h1 className="text-2xl sm:text-3xl font-black tracking-tight">
+            <span className="chef-stamp">Profile</span>
+          </h1>
+        </Link>
+        <Link
+          href="/"
+          className="text-xs text-zinc-400 hover:text-coral-300 transition uppercase tracking-wider font-semibold"
+        >
+          Back to meals
+        </Link>
+      </div>
+    </header>
+  );
+}
+
+interface ProfileCardProps {
+  profile: UserProfile;
+  onEdit: () => void;
+  onUploadAvatar: (file: File) => Promise<UserProfile>;
+}
+
+function ProfileCard({ profile, onEdit, onUploadAvatar }: ProfileCardProps) {
+  return (
+    <section className="rounded-2xl border border-zinc-800 bg-zinc-900/60 backdrop-blur p-6 sm:p-8 brand-stamp">
+      <div className="flex flex-col sm:flex-row gap-6 sm:items-center">
+        <AvatarBlock profile={profile} onUploadAvatar={onUploadAvatar} />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h2 className="text-2xl sm:text-3xl font-black tracking-tight text-white truncate">
+              @{profile.preferredUsername}
+            </h2>
+            <VisibilityBadge visibility={profile.profileVisibility} />
+          </div>
+          <p className="text-zinc-300 text-base sm:text-lg mt-1 truncate">
+            {profile.displayName}
+          </p>
+          <p className="text-zinc-500 text-sm mt-1 truncate">{profile.email}</p>
+          <button
+            type="button"
+            onClick={onEdit}
+            className="mt-4 inline-flex bg-gradient-to-r from-coral-500 to-coral-400 hover:from-coral-400 hover:to-coral-300 text-white font-bold uppercase tracking-wider px-4 py-2 rounded-lg text-sm transition shadow-lg shadow-coral-500/20 focus:outline-none focus:ring-2 focus:ring-coral-400/50"
+          >
+            Edit profile
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function AvatarBlock({
+  profile,
+  onUploadAvatar,
+}: {
+  profile: UserProfile;
+  onUploadAvatar: (file: File) => Promise<UserProfile>;
+}) {
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handlePick = async (file: File) => {
+    setUploading(true);
+    setError(null);
+    try {
+      await onUploadAvatar(file);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Upload failed');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <div className="relative shrink-0">
+      <label
+        className="group relative block h-28 w-28 rounded-full overflow-hidden border-2 border-zinc-700 hover:border-coral-400 transition cursor-pointer focus-within:ring-2 focus-within:ring-coral-400/50"
+        aria-label="Change avatar"
+      >
+        {profile.avatarUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={profile.avatarUrl}
+            alt=""
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          <span
+            className="h-full w-full grid place-items-center text-3xl font-black uppercase text-white bg-gradient-to-br from-coral-500 to-flame-500"
+            aria-hidden="true"
+          >
+            {profile.preferredUsername.charAt(0)}
+          </span>
+        )}
+        <span
+          aria-hidden="true"
+          className={`absolute inset-0 grid place-items-center bg-black/60 text-xs font-bold uppercase tracking-wider text-white transition ${
+            uploading ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+          }`}
+        >
+          {uploading ? 'Uploading…' : 'Change'}
+        </span>
+        <input
+          type="file"
+          accept="image/png,image/jpeg,image/webp"
+          className="sr-only"
+          disabled={uploading}
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) void handlePick(file);
+            e.target.value = '';
+          }}
+        />
+      </label>
+      {error && (
+        <p
+          role="alert"
+          className="absolute left-0 right-0 -bottom-6 text-[11px] text-coral-300 text-center"
+        >
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function VisibilityBadge({ visibility }: { visibility: 'public' | 'private' }) {
+  const isPublic = visibility === 'public';
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-[10px] font-bold uppercase tracking-wider px-2 py-1 rounded-md border ${
+        isPublic
+          ? 'bg-emerald-500/10 text-emerald-300 border-emerald-500/30'
+          : 'bg-zinc-800 text-zinc-300 border-zinc-700'
+      }`}
+    >
+      {isPublic ? 'Public' : 'Private'}
+    </span>
+  );
+}
+
+function StatsGrid() {
+  // v1: zeros-only placeholders. Real values land when recipes/friends ship.
+  const stats: { label: string; value: string }[] = [
+    { label: 'Recipes added', value: '0' },
+    { label: 'Recipes made', value: '0' },
+    { label: 'Avg rating', value: '–' },
+    { label: 'Friends', value: '0' },
+  ];
+
+  return (
+    <section className="mt-6 grid grid-cols-2 sm:grid-cols-4 gap-3">
+      {stats.map((s) => (
+        <div
+          key={s.label}
+          className="rounded-xl border border-zinc-800 bg-zinc-900/60 p-4 text-center"
+        >
+          <div className="font-display text-3xl font-black text-coral-300 tracking-tight">
+            {s.value}
+          </div>
+          <div className="text-[11px] uppercase tracking-wider text-zinc-500 mt-1">
+            {s.label}
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+function ProfileLoading() {
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <div className="text-center">
+        <div className="text-coral-400 text-3xl animate-pulse" aria-hidden="true">
+          🔥
+        </div>
+        <div className="text-zinc-500 text-sm mt-2 italic">
+          plating the profile…
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ProfileError({ message }: { message: string }) {
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4">
+      <div className="max-w-md text-center">
+        <div className="text-coral-400 text-3xl" aria-hidden="true">
+          🍳
+        </div>
+        <h1 className="font-display text-2xl font-black uppercase tracking-wide mt-3">
+          Couldn’t load profile
+        </h1>
+        <p className="text-zinc-400 text-sm mt-2">{message}</p>
+        <Link
+          href="/"
+          className="mt-5 inline-block bg-zinc-900 hover:bg-zinc-800 border border-zinc-800 hover:border-coral-500/50 text-zinc-100 px-4 py-2 rounded-lg text-sm font-semibold transition"
+        >
+          Back to meals
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/EditProfileModal.tsx
+++ b/src/components/EditProfileModal.tsx
@@ -1,0 +1,281 @@
+'use client';
+import { useEffect, useRef, useState } from 'react';
+import Modal from './Modal';
+import {
+  EditProfileFields,
+  ProfileVisibility,
+  UserProfile,
+} from '@/lib/users';
+
+interface Props {
+  open: boolean;
+  profile: UserProfile;
+  onClose: () => void;
+  onSave: (fields: EditProfileFields) => Promise<UserProfile>;
+  onUploadAvatar: (file: File) => Promise<UserProfile>;
+}
+
+const ACCEPTED_TYPES = 'image/png,image/jpeg,image/webp';
+const MAX_AVATAR_BYTES = 5 * 1024 * 1024; // 5 MB
+const DISPLAY_NAME_MIN = 1;
+const DISPLAY_NAME_MAX = 50;
+
+const inputCls =
+  'w-full bg-zinc-950 border border-zinc-700 rounded-lg px-3 py-2.5 text-sm text-zinc-100 placeholder:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-coral-400/40 focus:border-coral-400 transition disabled:opacity-50';
+const labelCls =
+  'block text-xs font-semibold uppercase tracking-wider text-zinc-400 mb-1.5';
+
+export default function EditProfileModal({
+  open,
+  profile,
+  onClose,
+  onSave,
+  onUploadAvatar,
+}: Props) {
+  const [displayName, setDisplayName] = useState(profile.displayName);
+  const [visibility, setVisibility] = useState<ProfileVisibility>(
+    profile.profileVisibility,
+  );
+  const [pendingFile, setPendingFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Reset form whenever a new profile is loaded into the modal (e.g. user
+  // opens it, edits, closes, opens again).
+  useEffect(() => {
+    if (!open) return;
+    setDisplayName(profile.displayName);
+    setVisibility(profile.profileVisibility);
+    setPendingFile(null);
+    setPreviewUrl(null);
+    setError(null);
+  }, [open, profile.displayName, profile.profileVisibility]);
+
+  // Manage object URL lifecycle so we don't leak blobs.
+  useEffect(() => {
+    if (!pendingFile) {
+      setPreviewUrl(null);
+      return;
+    }
+    const url = URL.createObjectURL(pendingFile);
+    setPreviewUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, [pendingFile]);
+
+  const trimmedName = displayName.trim();
+  const nameValid =
+    trimmedName.length >= DISPLAY_NAME_MIN &&
+    trimmedName.length <= DISPLAY_NAME_MAX;
+
+  const dirty =
+    trimmedName !== profile.displayName ||
+    visibility !== profile.profileVisibility ||
+    !!pendingFile;
+
+  const handleFile = (file: File | null) => {
+    setError(null);
+    if (!file) {
+      setPendingFile(null);
+      return;
+    }
+    if (!['image/png', 'image/jpeg', 'image/webp'].includes(file.type)) {
+      setError('Avatar must be a PNG, JPEG, or WebP.');
+      return;
+    }
+    if (file.size > MAX_AVATAR_BYTES) {
+      setError('Avatar must be 5 MB or smaller.');
+      return;
+    }
+    setPendingFile(file);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!nameValid || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      // Avatar first so the final edit reflects the new URL atomically.
+      if (pendingFile) {
+        await onUploadAvatar(pendingFile);
+      }
+
+      const fields: EditProfileFields = {};
+      if (trimmedName !== profile.displayName) fields.displayName = trimmedName;
+      if (visibility !== profile.profileVisibility)
+        fields.profileVisibility = visibility;
+
+      if (Object.keys(fields).length > 0) {
+        await onSave(fields);
+      }
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const avatarShown = previewUrl ?? profile.avatarUrl ?? null;
+
+  return (
+    <Modal open={open} onClose={onClose} title="Edit profile">
+      <form onSubmit={handleSubmit} className="space-y-5">
+        <div>
+          <span className={labelCls}>Avatar</span>
+          <div className="flex items-center gap-4">
+            <div className="h-20 w-20 rounded-full overflow-hidden border border-zinc-700 bg-zinc-800 grid place-items-center">
+              {avatarShown ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={avatarShown}
+                  alt=""
+                  className="h-full w-full object-cover"
+                />
+              ) : (
+                <span
+                  className="text-xl font-black uppercase text-white bg-gradient-to-br from-coral-500 to-flame-500 h-full w-full grid place-items-center"
+                  aria-hidden="true"
+                >
+                  {profile.preferredUsername.charAt(0)}
+                </span>
+              )}
+            </div>
+            <div className="flex flex-col gap-2">
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 hover:border-coral-500/50 text-zinc-100 px-3 py-1.5 rounded-md text-xs font-semibold uppercase tracking-wider transition focus:outline-none focus:ring-2 focus:ring-coral-400/40"
+              >
+                {avatarShown ? 'Change' : 'Upload'}
+              </button>
+              {pendingFile && (
+                <button
+                  type="button"
+                  onClick={() => handleFile(null)}
+                  className="text-xs text-zinc-400 hover:text-coral-300 transition"
+                >
+                  Cancel selection
+                </button>
+              )}
+              <p className="text-[11px] text-zinc-500">
+                PNG, JPEG, or WebP. Max 5 MB.
+              </p>
+            </div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept={ACCEPTED_TYPES}
+              className="sr-only"
+              onChange={(e) => handleFile(e.target.files?.[0] ?? null)}
+            />
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="displayName" className={labelCls}>
+            Display name
+          </label>
+          <input
+            id="displayName"
+            className={inputCls}
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            placeholder="Your name"
+            maxLength={DISPLAY_NAME_MAX}
+            required
+            aria-invalid={!nameValid}
+          />
+          <p className="mt-1 text-[11px] text-zinc-500">
+            {trimmedName.length}/{DISPLAY_NAME_MAX} characters
+          </p>
+        </div>
+
+        <div>
+          <span className={labelCls}>Profile visibility</span>
+          <div
+            role="radiogroup"
+            aria-label="Profile visibility"
+            className="flex bg-zinc-900 rounded-lg p-0.5 border border-zinc-800 w-fit"
+          >
+            <VisibilityOption
+              value="public"
+              current={visibility}
+              onChange={setVisibility}
+              label="Public"
+            />
+            <VisibilityOption
+              value="private"
+              current={visibility}
+              onChange={setVisibility}
+              label="Private"
+            />
+          </div>
+          <p className="mt-1.5 text-[11px] text-zinc-500">
+            {visibility === 'public'
+              ? 'Anyone can find you by handle and see your profile.'
+              : 'Your profile is only visible to you.'}
+          </p>
+        </div>
+
+        {error && (
+          <div
+            role="alert"
+            className="text-xs text-coral-300 bg-coral-900/30 border border-coral-800 rounded-md px-3 py-2"
+          >
+            {error}
+          </div>
+        )}
+
+        <div className="flex items-center gap-2 pt-1">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="px-4 py-2.5 rounded-lg text-sm font-semibold text-zinc-300 hover:text-white hover:bg-zinc-800 transition disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting || !nameValid || !dirty}
+            className="flex-1 bg-gradient-to-r from-coral-500 to-coral-400 hover:from-coral-400 hover:to-coral-300 disabled:opacity-40 disabled:cursor-not-allowed text-white font-bold uppercase tracking-wider py-2.5 px-4 rounded-lg transition shadow-lg shadow-coral-500/20 focus:outline-none focus:ring-2 focus:ring-coral-400/50"
+          >
+            {submitting ? 'Saving…' : 'Save changes'}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}
+
+function VisibilityOption({
+  value,
+  current,
+  onChange,
+  label,
+}: {
+  value: ProfileVisibility;
+  current: ProfileVisibility;
+  onChange: (v: ProfileVisibility) => void;
+  label: string;
+}) {
+  const active = current === value;
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={active}
+      onClick={() => onChange(value)}
+      className={`px-4 py-1.5 rounded-md text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-coral-400/40 ${
+        active
+          ? 'bg-zinc-800 text-white'
+          : 'text-zinc-500 hover:text-zinc-200'
+      }`}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { ViewMode } from '@/types';
 import { useAuth } from '@/lib/auth-context';
+import { useProfile } from '@/lib/use-profile';
 
 interface Props {
   mealCount: number;
@@ -68,6 +69,7 @@ export default function Header({ mealCount, cookedCount, view, onViewChange, onA
 
 function UserMenu() {
   const { user, isAuthenticated, signOut } = useAuth();
+  const { profile } = useProfile();
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -99,7 +101,12 @@ function UserMenu() {
     );
   }
 
-  const handle = user.preferredUsername;
+  // Prefer the freshly-loaded profile; fall back to the auth context (avoids
+  // an empty header during the brief window before /users/me resolves).
+  const handle = profile?.preferredUsername ?? user.preferredUsername;
+  const label = profile?.displayName?.trim() || handle;
+  const avatarUrl = profile?.avatarUrl ?? null;
+  const initial = (label || handle).charAt(0);
 
   return (
     <div ref={ref} className="relative">
@@ -108,20 +115,38 @@ function UserMenu() {
         onClick={() => setOpen((v) => !v)}
         aria-haspopup="menu"
         aria-expanded={open}
-        className="flex items-center gap-2 bg-zinc-900 hover:bg-zinc-800 border border-zinc-800 hover:border-coral-500/50 text-zinc-100 px-3 py-2 rounded-lg text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-coral-400/40"
+        aria-label={`Account menu for ${label}`}
+        className="flex items-center gap-2 bg-zinc-900 hover:bg-zinc-800 border border-zinc-800 hover:border-coral-500/50 text-zinc-100 px-2.5 py-1.5 rounded-lg text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-coral-400/40"
       >
-        <span className="h-6 w-6 rounded-full grid place-items-center bg-gradient-to-br from-coral-500 to-flame-500 text-white text-xs font-black uppercase">
-          {handle.charAt(0)}
+        <span className="h-7 w-7 rounded-full overflow-hidden bg-zinc-800 grid place-items-center shrink-0">
+          {avatarUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={avatarUrl}
+              alt=""
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <span className="h-full w-full grid place-items-center bg-gradient-to-br from-coral-500 to-flame-500 text-white text-xs font-black uppercase">
+              {initial}
+            </span>
+          )}
         </span>
-        <span className="max-w-[8rem] truncate">@{handle}</span>
-        <span className="text-zinc-500">▾</span>
+        <span className="max-w-[8rem] truncate">{label}</span>
+        <span className="text-zinc-500" aria-hidden="true">▾</span>
       </button>
 
       {open && (
         <div
           role="menu"
-          className="absolute right-0 top-full mt-2 w-48 rounded-lg border border-zinc-800 bg-zinc-900 shadow-lg shadow-black/40 overflow-hidden z-40"
+          className="absolute right-0 top-full mt-2 w-56 rounded-lg border border-zinc-800 bg-zinc-900 shadow-lg shadow-black/40 overflow-hidden z-40"
         >
+          <div className="px-3 py-2 border-b border-zinc-800">
+            <div className="text-sm font-semibold text-zinc-100 truncate">
+              {label}
+            </div>
+            <div className="text-xs text-zinc-500 truncate">@{handle}</div>
+          </div>
           <Link
             role="menuitem"
             href="/profile"

--- a/src/lib/use-profile.ts
+++ b/src/lib/use-profile.ts
@@ -1,0 +1,84 @@
+import useSWR from 'swr';
+import { useCallback } from 'react';
+import { useAuth } from './auth-context';
+import {
+  EditProfileFields,
+  ProfileNotReadyError,
+  UserProfile,
+  usersApi,
+} from './users';
+
+const PROFILE_KEY = 'users:me';
+
+interface UseProfileResult {
+  profile: UserProfile | null;
+  isLoading: boolean;
+  error: Error | null;
+  refresh: () => Promise<UserProfile | undefined>;
+  edit: (fields: EditProfileFields) => Promise<UserProfile>;
+  uploadAvatar: (file: File) => Promise<UserProfile>;
+}
+
+/**
+ * Fetch /users/me with one automatic retry on ProfileNotReadyError.
+ *
+ * Cognito's PostConfirmation trigger writes the user row asynchronously, so the
+ * very first call right after sign-up can race and 404. One retry with a brief
+ * delay covers that gap without hiding real errors.
+ */
+async function fetchProfileWithRetry(): Promise<UserProfile> {
+  try {
+    return await usersApi.me();
+  } catch (err) {
+    if (err instanceof ProfileNotReadyError) {
+      await new Promise((r) => setTimeout(r, 750));
+      return await usersApi.me();
+    }
+    throw err;
+  }
+}
+
+export function useProfile(): UseProfileResult {
+  const { isAuthenticated } = useAuth();
+
+  const { data, error, isLoading, mutate } = useSWR<UserProfile, Error>(
+    isAuthenticated ? PROFILE_KEY : null,
+    fetchProfileWithRetry,
+    {
+      // We already have application-level retry for the PostConfirmation race;
+      // SWR's default exponential retry only adds noise on real errors.
+      shouldRetryOnError: false,
+      revalidateOnFocus: false,
+    },
+  );
+
+  const refresh = useCallback(() => mutate(), [mutate]);
+
+  const edit = useCallback(
+    async (fields: EditProfileFields) => {
+      const updated = await usersApi.edit(fields);
+      await mutate(updated, { revalidate: false });
+      return updated;
+    },
+    [mutate],
+  );
+
+  const uploadAvatar = useCallback(
+    async (file: File) => {
+      const finalUrl = await usersApi.uploadAvatar(file);
+      const updated = await usersApi.edit({ avatarUrl: finalUrl });
+      await mutate(updated, { revalidate: false });
+      return updated;
+    },
+    [mutate],
+  );
+
+  return {
+    profile: data ?? null,
+    isLoading: isAuthenticated ? isLoading : false,
+    error: error ?? null,
+    refresh,
+    edit,
+    uploadAvatar,
+  };
+}

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -1,0 +1,129 @@
+import { AuthRequiredError } from './storage';
+import { getJwtToken } from './auth-context';
+
+const USERS_API_BASE =
+  process.env.NEXT_PUBLIC_USERS_API_URL || 'https://api.xomware.com';
+
+export type ProfileVisibility = 'public' | 'private';
+
+/** Full profile returned by /users/me and /users/edit. */
+export interface UserProfile {
+  userId: string;
+  email: string;
+  preferredUsername: string;
+  displayName: string;
+  avatarUrl: string | null;
+  profileVisibility: ProfileVisibility;
+  createdAt: string;
+}
+
+/** Public lookup shape — never exposes email. */
+export interface PublicUserProfile {
+  userId: string;
+  preferredUsername: string;
+  displayName: string;
+  avatarUrl: string | null;
+  profileVisibility: ProfileVisibility;
+}
+
+export interface EditProfileFields {
+  displayName?: string;
+  avatarUrl?: string | null;
+  profileVisibility?: ProfileVisibility;
+}
+
+export type AvatarContentType = 'image/png' | 'image/jpeg' | 'image/webp';
+
+interface PresignAvatarResponse {
+  uploadUrl: string;
+  finalUrl: string;
+}
+
+/**
+ * Errors that should not blow up the SWR boundary — currently just 404 from
+ * /users/me when the PostConfirmation Lambda hasn't fired yet. Callers
+ * (the SWR hook) detect this and retry once.
+ */
+export class ProfileNotReadyError extends Error {
+  constructor() {
+    super('Profile not ready');
+    this.name = 'ProfileNotReadyError';
+  }
+}
+
+async function authHeaders(): Promise<Record<string, string>> {
+  const token = await getJwtToken();
+  if (!token) throw new AuthRequiredError();
+  return { Authorization: `Bearer ${token}` };
+}
+
+function handleUnauthorized() {
+  if (typeof window === 'undefined') return;
+  setTimeout(() => {
+    const next = encodeURIComponent(window.location.pathname + window.location.search);
+    window.location.replace(`/auth/sign-in?next=${next}`);
+  }, 0);
+}
+
+async function apiPost<T>(path: string, body?: unknown): Promise<T> {
+  const auth = await authHeaders();
+  const res = await fetch(`${USERS_API_BASE}${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...auth,
+    },
+    body: body == null ? undefined : JSON.stringify(body),
+  });
+  if (res.status === 401) {
+    handleUnauthorized();
+    throw new AuthRequiredError();
+  }
+  if (res.status === 404 && path === '/users/me') {
+    throw new ProfileNotReadyError();
+  }
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Users API error ${res.status}: ${text}`);
+  }
+  if (res.status === 204) return undefined as T;
+  return res.json();
+}
+
+export const usersApi = {
+  me: async (): Promise<UserProfile> => apiPost<UserProfile>('/users/me'),
+
+  getByHandle: async (handle: string): Promise<PublicUserProfile> =>
+    apiPost<PublicUserProfile>('/users/get-by-handle', { handle }),
+
+  edit: async (fields: EditProfileFields): Promise<UserProfile> =>
+    apiPost<UserProfile>('/users/edit', fields),
+
+  presignAvatar: async (
+    contentType: AvatarContentType,
+  ): Promise<PresignAvatarResponse> =>
+    apiPost<PresignAvatarResponse>('/users/presign-avatar', { contentType }),
+
+  /**
+   * Full upload flow: ask the API for a presigned PUT, push the raw file body
+   * directly to S3, and return the CDN URL. Callers persist `finalUrl` via
+   * `usersApi.edit({ avatarUrl })`.
+   */
+  uploadAvatar: async (file: File): Promise<string> => {
+    const ct = file.type;
+    if (ct !== 'image/png' && ct !== 'image/jpeg' && ct !== 'image/webp') {
+      throw new Error('Avatar must be a PNG, JPEG, or WebP image');
+    }
+    const { uploadUrl, finalUrl } = await usersApi.presignAvatar(ct);
+    const putRes = await fetch(uploadUrl, {
+      method: 'PUT',
+      headers: { 'Content-Type': ct },
+      body: file,
+    });
+    if (!putRes.ok) {
+      const text = await putRes.text().catch(() => '');
+      throw new Error(`Avatar upload failed (${putRes.status}): ${text}`);
+    }
+    return finalUrl;
+  },
+};


### PR DESCRIPTION
## Summary

Frontend half of Phase 3 — wires Xom Appétit into the shared Xomware users service at `api.xomware.com`.

- New `src/lib/users.ts` users API client (me, getByHandle, edit, presignAvatar, uploadAvatar)
- New `useProfile()` SWR hook with auto-retry on the PostConfirmation race
- New `/profile` page (avatar w/ hover-upload, handle, display name, email, visibility badge, v1 zero stats)
- New `EditProfileModal` (display name 1-50, visibility toggle, file picker w/ preview)
- `Header` user menu now shows avatar + displayName from the live profile, handle as subtitle
- Deploy workflow pulls `NEXT_PUBLIC_USERS_API_URL` + `NEXT_PUBLIC_AVATARS_CDN_URL` from SSM

## Dependency — DO NOT MERGE YET

Requires `xomware-infrastructure` to apply the shared users service first. The deploy workflow reads:

- `/xomware/shared/users-api/url`
- `/xomware/shared/avatars/cdn-url`

…both Terraform-managed. Build will fail at the SSM step until those exist.

## Design notes / tradeoffs

- **Loading states.** Profile page shows the same coral 🔥 loader the home page uses, both for auth resolution and the SWR fetch. No partial render — users see a loader, then the full card.
- **PostConfirmation race.** `useProfile` retries the 404 once with a 750 ms delay. SWR's built-in retry is disabled to avoid noise on real errors. If both attempts 404 we surface the error UI rather than spinning forever.
- **Header avatar fallback.** Header reads from both `useAuth().user` and `useProfile().profile`. If the profile fetch hasn't resolved yet, we fall back to the Cognito attribute so the menu never renders empty during the initial paint.
- **Avatars upload directly to S3.** Presigned PUT, raw file body, no API proxy. Client-side validation: png/jpeg/webp only, 5 MB cap.
- **Avatar updates atomicity.** EditProfileModal uploads the avatar first, then sends the rest of the edits in one `/users/edit` call. SWR is mutated optimistically with the server response so the page rerenders instantly.
- **Static export.** Page is a client component (`'use client'`) under `useRequireAuth()` since the project is statically exported and middleware isn't available.

## Test plan

- [ ] Apply infra PR first
- [ ] Local `npm run build` succeeds with `NEXT_PUBLIC_USERS_API_URL=https://api.xomware.com`
- [ ] Sign in → land on `/`, header shows avatar + display name
- [ ] Click avatar menu → "Profile" → `/profile` renders with full info
- [ ] Edit profile → change display name → header updates immediately
- [ ] Edit profile → toggle public/private → badge updates
- [ ] Upload avatar (png/jpeg/webp) → final URL on `cdn.xomware.com`, header refreshes
- [ ] Sign up new user → first `/profile` visit retries past PostConfirmation lag and renders successfully