### PR TITLE
fix(auth): surface Cognito err.name so real errors reach the UI

### DIFF
--- a/src/lib/auth-context.tsx
+++ b/src/lib/auth-context.tsx
@@ -152,12 +152,19 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           typeof crypto !== 'undefined' && crypto.randomUUID
             ? crypto.randomUUID()
             : `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        // preferred_username CAN'T be a userAttribute during SignUp because
+        // alias_attributes includes it — Cognito reserves alias attrs for
+        // confirmed accounts only. Pass it via clientMetadata so the
+        // PostConfirmation Lambda picks it up and writes it to the users
+        // DDB row (and later to the Cognito alias once we wire that).
         await amplifySignUp({
           username: opaqueUsername,
           password,
           options: {
             userAttributes: {
               email,
+            },
+            clientMetadata: {
               preferred_username: preferredUsername,
             },
           },

--- a/src/lib/auth-context.tsx
+++ b/src/lib/auth-context.tsx
@@ -290,7 +290,13 @@ export function useRequireAuth() {
 // ---- Helpers ----
 
 function errorMessage(err: unknown): string {
-  if (err instanceof Error) return err.message;
+  // Amplify v6 puts the Cognito exception class on err.name and the human
+  // text on err.message — surface both so the UI doesn't show a meaningless
+  // 'Authentication required' when something specific went wrong.
+  if (err instanceof Error) {
+    const name = err.name && err.name !== 'Error' ? err.name : '';
+    return name && err.message ? `${name}: ${err.message}` : err.message || name || 'Unexpected error';
+  }
   if (typeof err === 'string') return err;
   return 'Unexpected error';
 }


### PR DESCRIPTION
Amplify v6 puts the exception class on err.name. Old errorMessage returned only err.message, swallowing the class name and showing generic text. Now surfaces 'ClassName: message'.