### PR TITLE
Phase 4 (frontend): activate Google sign-in

### DIFF
--- a/src/app/auth/sign-in/page.tsx
+++ b/src/app/auth/sign-in/page.tsx
@@ -124,11 +124,10 @@ export default function SignInPage() {
           type="button"
           onClick={() => void signInWithGoogle()}
           className={authSecondaryBtnClass}
-          aria-label="Sign in with Google (coming soon)"
-          title="Coming soon"
+          aria-label="Sign in with Google"
+          disabled={submitting}
         >
           Sign in with Google
-          <span className="ml-2 text-xs text-zinc-400">(soon)</span>
         </button>
       </form>
     </AuthShell>

--- a/src/app/auth/sign-up/page.tsx
+++ b/src/app/auth/sign-up/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import AuthShell, {
   authInputClass,
   authPrimaryBtnClass,
+  authSecondaryBtnClass,
 } from '@/components/AuthShell';
 import { useAuth } from '@/lib/auth-context';
 
@@ -30,7 +31,7 @@ function validateHandle(handle: string): string | null {
 }
 
 export default function SignUpPage() {
-  const { signUp } = useAuth();
+  const { signUp, signInWithGoogle } = useAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [handle, setHandle] = useState('');
@@ -157,6 +158,22 @@ export default function SignUpPage() {
 
         <button type="submit" className={authPrimaryBtnClass} disabled={submitting}>
           {submitting ? 'Creating account…' : 'Create account'}
+        </button>
+
+        <div className="flex items-center gap-3 my-2">
+          <div className="h-px flex-1 bg-zinc-800" />
+          <span className="text-xs uppercase tracking-wider text-zinc-600">or</span>
+          <div className="h-px flex-1 bg-zinc-800" />
+        </div>
+
+        <button
+          type="button"
+          onClick={() => void signInWithGoogle()}
+          className={authSecondaryBtnClass}
+          aria-label="Continue with Google"
+          disabled={submitting}
+        >
+          Continue with Google
         </button>
       </form>
     </AuthShell>

--- a/src/lib/auth-context.tsx
+++ b/src/lib/auth-context.tsx
@@ -203,16 +203,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const signInWithGoogle = useCallback(async () => {
-    // Stub: Phase 4 wires the Google IdP. For now this is a no-op so the
-    // button can render without crashing. If/when Google is provisioned in
-    // the user pool, swap this for:
-    //   await signInWithRedirect({ provider: 'Google' });
-    // Reference imported to keep TS happy if we wire it later.
-    void signInWithRedirect;
-    if (typeof window !== 'undefined') {
-      // Soft signal during local testing; production button can show a tooltip.
-      console.info('[auth] Google sign-in is not wired yet (Phase 4).');
-    }
+    // Phase 4: kick off Google federated sign-in via Cognito Hosted UI.
+    // Amplify navigates the page to Google's consent screen; control returns
+    // to the app at /auth/callback after the round trip.
+    await signInWithRedirect({ provider: 'Google' });
   }, []);
 
   const signOut = useCallback(async () => {


### PR DESCRIPTION
## Summary

Companion to xomware-infrastructure#33. Replaces the no-op signInWithGoogle stub with a real Amplify signInWithRedirect call, and activates the previously stubbed sign-in button.

- auth-context.tsx: signInWithGoogle now calls signInWithRedirect({ provider: 'Google' }).
- sign-in page: drops the 'coming soon' label/tooltip on the existing button.
- sign-up page: adds a matching Continue with Google button + divider for parity.

Depends on the infra PR being merged + applied first (Google IdP must exist on the pool before redirect succeeds).

## Test plan

- [ ] After infra apply, click Sign in with Google on https://xomappetit.xomware.com/auth/sign-in -> Google consent -> /auth/callback -> signed in
- [ ] Same from /auth/sign-up
- [ ] Existing email-password user signs in with Google using same email -> linked, no duplicate; profile still works