### PR TITLE
fix(ui): persistent header, no empty-state flicker, page-level CTAs

### DIFF
--- a/src/app/cooks/new/page.tsx
+++ b/src/app/cooks/new/page.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useRequireAuth } from '@/lib/auth-context';
 import { useRecipe, logCook } from '@/lib/hooks';
-import Header from '@/components/Header';
 import { CookForm, CookFormValues } from '@/components/CookForm';
 
 export default function NewCookPage() {
@@ -45,7 +44,6 @@ function NewCookInner() {
 
   return (
     <div>
-      <Header />
       <main className="max-w-2xl mx-auto px-4 py-6 space-y-6">
         <div className="flex items-center justify-between">
           <h2 className="font-display text-2xl font-black uppercase tracking-wide">

--- a/src/app/cooks/page.tsx
+++ b/src/app/cooks/page.tsx
@@ -2,7 +2,6 @@
 import Link from 'next/link';
 import { useRequireAuth, useAuth } from '@/lib/auth-context';
 import { useMyCooks, useRecipes } from '@/lib/hooks';
-import Header from '@/components/Header';
 import { Cook, Recipe } from '@/types';
 
 export default function CooksPage() {
@@ -11,51 +10,39 @@ export default function CooksPage() {
   const { cooks, isLoading } = useMyCooks();
   const { recipes } = useRecipes();
 
-  if (authLoading || !isAuthenticated) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-coral-400 text-3xl animate-pulse" aria-hidden="true">
-          🔥
-        </div>
-      </div>
-    );
-  }
-
   const recipeMap = new Map<string, Recipe>(recipes.map((r) => [r.recipeId, r]));
-
-  const subtitle = (
-    <>
-      <span className="text-coral-400 font-semibold">{cooks.length}</span>{' '}
-      {cooks.length === 1 ? 'cook session' : 'cook sessions'}
-    </>
-  );
+  const dataReady = isAuthenticated && !isLoading;
 
   return (
-    <div>
-      <Header subtitle={subtitle} />
-      <main className="max-w-3xl mx-auto px-4 py-6 space-y-4">
-        <h2 className="font-display text-2xl font-black uppercase tracking-wide">
-          Your cook log
-        </h2>
+    <main className="max-w-3xl mx-auto px-4 py-6 space-y-4">
+      <div>
+        <h2 className="font-display text-2xl font-black uppercase tracking-wide">Cooks</h2>
+        <p className="text-sm text-zinc-400 mt-1">
+          <span className="text-coral-400 font-semibold">{cooks.length}</span>{' '}
+          {cooks.length === 1 ? 'cook session' : 'cook sessions'}
+        </p>
+      </div>
 
-        {isLoading ? (
-          <div className="text-center py-16 text-zinc-500 italic">loading…</div>
-        ) : cooks.length === 0 ? (
-          <EmptyCooks />
-        ) : (
-          <ul className="space-y-3">
-            {cooks.map((c) => (
-              <CookRow
-                key={c.cookId}
-                cook={c}
-                recipeName={recipeMap.get(c.recipeId)?.name ?? 'Unknown recipe'}
-                userId={user?.sub ?? null}
-              />
-            ))}
-          </ul>
-        )}
-      </main>
-    </div>
+      {!dataReady || authLoading ? (
+        <div className="text-center py-16">
+          <div className="text-coral-400 text-3xl animate-pulse" aria-hidden="true">🔥</div>
+          <div className="text-zinc-500 text-sm mt-2 italic">heating up the kitchen…</div>
+        </div>
+      ) : cooks.length === 0 ? (
+        <EmptyCooks />
+      ) : (
+        <ul className="space-y-3">
+          {cooks.map((c) => (
+            <CookRow
+              key={c.cookId}
+              cook={c}
+              recipeName={recipeMap.get(c.recipeId)?.name ?? 'Unknown recipe'}
+              userId={user?.sub ?? null}
+            />
+          ))}
+        </ul>
+      )}
+    </main>
   );
 }
 

--- a/src/app/cooks/view/page.tsx
+++ b/src/app/cooks/view/page.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useRequireAuth, useAuth } from '@/lib/auth-context';
 import { useCook, useRecipe } from '@/lib/hooks';
-import Header from '@/components/Header';
 import { CookForm, CookFormValues } from '@/components/CookForm';
 import { RatingStars } from '@/components/RatingStars';
 
@@ -61,7 +60,6 @@ function CookViewInner() {
   if (editing) {
     return (
       <div>
-        <Header />
         <main className="max-w-2xl mx-auto px-4 py-6 space-y-6">
           <div className="flex items-center justify-between">
             <h2 className="font-display text-2xl font-black uppercase tracking-wide">
@@ -102,7 +100,6 @@ function CookViewInner() {
 
   return (
     <div>
-      <Header />
       <main className="max-w-3xl mx-auto px-4 py-6 space-y-6">
         <div className="flex items-center justify-between">
           <Link

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import Script from 'next/script';
 import './globals.css';
 import { AuthProvider } from '@/lib/auth-context';
+import AppShell from '@/components/AppShell';
 
 export const metadata: Metadata = {
   title: 'Xom Appétit',
@@ -31,7 +32,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             </Script>
           </>
         )}
-        <AuthProvider>{children}</AuthProvider>
+        <AuthProvider>
+          <AppShell>{children}</AppShell>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,6 @@
 import Link from 'next/link';
 import { useRequireAuth } from '@/lib/auth-context';
 import { useRecipes } from '@/lib/hooks';
-import Header from '@/components/Header';
 import { RecipeCard } from '@/components/RecipeCard';
 import { MASCOTS, mascotFor } from '@/components/Mascot';
 
@@ -10,58 +9,51 @@ export default function Home() {
   const { isAuthenticated, isLoading: authLoading } = useRequireAuth();
   const { recipes, isLoading } = useRecipes();
 
-  if (authLoading || !isAuthenticated) {
-    return <PageLoading />;
-  }
-
-  const subtitle = (
-    <>
-      <span className="text-coral-400 font-semibold">{recipes.length}</span>{' '}
-      {recipes.length === 1 ? 'recipe' : 'recipes'}
-    </>
-  );
-
-  const actions = (
-    <Link
-      href="/recipes/new"
-      className="bg-gradient-to-r from-coral-500 to-coral-400 hover:from-coral-400 hover:to-coral-300 text-white px-4 py-2 rounded-lg text-sm font-bold uppercase tracking-wide transition shadow-lg shadow-coral-500/20 focus:outline-none focus:ring-2 focus:ring-coral-400/50"
-    >
-      + New recipe
-    </Link>
-  );
+  // While auth is settling OR we haven't done the first data load yet,
+  // show the kitchen-warmup spinner. Don't fall through to EmptyState
+  // mid-transition — that's what made "Welcome to Flavortown" blink.
+  const dataReady = isAuthenticated && !isLoading;
 
   return (
-    <div>
-      <Header subtitle={subtitle} actions={actions} />
-      <main className="max-w-6xl mx-auto px-4 py-6 space-y-6">
-        {isLoading ? (
-          <PageLoading inline />
-        ) : recipes.length === 0 ? (
-          <EmptyState />
-        ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            {recipes.map((r) => (
-              <RecipeCard key={r.recipeId} recipe={r} />
-            ))}
-          </div>
-        )}
-      </main>
-    </div>
+    <main className="max-w-6xl mx-auto px-4 py-6 space-y-6">
+      <div className="flex items-end justify-between gap-4 flex-wrap">
+        <div>
+          <h2 className="font-display text-2xl font-black uppercase tracking-wide">Recipes</h2>
+          <p className="text-sm text-zinc-400 mt-1">
+            <span className="text-coral-400 font-semibold">{recipes.length}</span>{' '}
+            {recipes.length === 1 ? 'recipe' : 'recipes'}
+          </p>
+        </div>
+        <Link
+          href="/recipes/new"
+          className="bg-gradient-to-r from-coral-500 to-coral-400 hover:from-coral-400 hover:to-coral-300 text-white px-4 py-2 rounded-lg text-sm font-bold uppercase tracking-wide transition shadow-lg shadow-coral-500/20 focus:outline-none focus:ring-2 focus:ring-coral-400/50"
+        >
+          + New recipe
+        </Link>
+      </div>
+
+      {!dataReady || authLoading ? (
+        <PageLoading />
+      ) : recipes.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {recipes.map((r) => (
+            <RecipeCard key={r.recipeId} recipe={r} />
+          ))}
+        </div>
+      )}
+    </main>
   );
 }
 
-function PageLoading({ inline }: { inline?: boolean }) {
-  const wrap = inline
-    ? 'text-center py-16'
-    : 'min-h-screen flex items-center justify-center';
+function PageLoading() {
   return (
-    <div className={wrap}>
-      <div className="text-center">
-        <div className="text-coral-400 text-3xl animate-pulse" aria-hidden="true">
-          🔥
-        </div>
-        <div className="text-zinc-500 text-sm mt-2 italic">heating up the kitchen…</div>
+    <div className="text-center py-16">
+      <div className="text-coral-400 text-3xl animate-pulse" aria-hidden="true">
+        🔥
       </div>
+      <div className="text-zinc-500 text-sm mt-2 italic">heating up the kitchen…</div>
     </div>
   );
 }

--- a/src/app/recipes/new/page.tsx
+++ b/src/app/recipes/new/page.tsx
@@ -3,7 +3,6 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useRequireAuth } from '@/lib/auth-context';
 import { useRecipes } from '@/lib/hooks';
-import Header from '@/components/Header';
 import { RecipeForm, RecipeFormValues } from '@/components/RecipeForm';
 
 export default function NewRecipePage() {
@@ -30,7 +29,6 @@ export default function NewRecipePage() {
 
   return (
     <div>
-      <Header />
       <main className="max-w-2xl mx-auto px-4 py-6 space-y-6">
         <div className="flex items-center justify-between">
           <h2 className="font-display text-2xl font-black uppercase tracking-wide">

--- a/src/app/recipes/view/page.tsx
+++ b/src/app/recipes/view/page.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useRequireAuth, useAuth } from '@/lib/auth-context';
 import { useRecipe } from '@/lib/hooks';
-import Header from '@/components/Header';
 import { RecipeForm, RecipeFormValues } from '@/components/RecipeForm';
 import { RecipeComments } from '@/components/RecipeComments';
 import { RatingStars } from '@/components/RatingStars';
@@ -85,7 +84,6 @@ function RecipeViewInner() {
   if (editing) {
     return (
       <div>
-        <Header />
         <main className="max-w-2xl mx-auto px-4 py-6 space-y-6">
           <div className="flex items-center justify-between">
             <h2 className="font-display text-2xl font-black uppercase tracking-wide">
@@ -112,7 +110,6 @@ function RecipeViewInner() {
 
   return (
     <div>
-      <Header />
       <main className="max-w-3xl mx-auto px-4 py-6 space-y-6">
         <div className="flex items-center justify-between">
           <Link

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,0 +1,22 @@
+'use client';
+import { usePathname } from 'next/navigation';
+import Header from './Header';
+
+/**
+ * Persistent app chrome. Mounts once via the root layout, so navigating
+ * between /, /cooks, /recipes/new, etc. does NOT remount the header — no
+ * flicker, no layout shift.
+ *
+ * Auth pages (sign-in/up/verify/callback) stand alone with their own
+ * AuthShell card, so we suppress the global header there.
+ */
+export default function AppShell({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname() || '/';
+  const showHeader = !pathname.startsWith('/auth');
+  return (
+    <>
+      {showHeader && <Header />}
+      {children}
+    </>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,30 +1,19 @@
 'use client';
 import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { useAuth } from '@/lib/auth-context';
 import { useProfile } from '@/lib/use-profile';
 
-interface Props {
-  title?: string;
-  subtitle?: React.ReactNode;
-  actions?: React.ReactNode;
-}
-
-export default function Header({ title = 'Xom Appétit', subtitle, actions }: Props) {
+export default function Header() {
   return (
-    <header className="border-b border-zinc-800 bg-gradient-to-b from-zinc-950 to-zinc-950/80 backdrop-blur sticky top-0 z-30">
-      <div className="max-w-6xl mx-auto px-4 py-4 flex flex-col sm:flex-row sm:items-end justify-between gap-4">
-        <div>
-          <Link href="/" className="inline-block focus:outline-none focus:ring-2 focus:ring-coral-400/50 rounded">
-            <h1 className="text-3xl sm:text-4xl font-black tracking-tight brand-bar">
-              <span className="chef-stamp">{title}</span>
-            </h1>
-          </Link>
-          {subtitle && <div className="text-zinc-400 text-sm mt-2">{subtitle}</div>}
-        </div>
-        <div className="flex gap-2 items-center flex-wrap">
+    <header className="border-b border-zinc-800 bg-zinc-950/95 backdrop-blur sticky top-0 z-30">
+      <div className="max-w-6xl mx-auto px-4 h-14 flex items-center justify-between gap-4">
+        <Link href="/" className="inline-block focus:outline-none focus:ring-2 focus:ring-coral-400/50 rounded">
+          <span className="text-xl font-black tracking-tight chef-stamp">Xom Appétit</span>
+        </Link>
+        <div className="flex items-center gap-2">
           <NavLinks />
-          {actions}
           <UserMenu />
         </div>
       </div>
@@ -33,21 +22,34 @@ export default function Header({ title = 'Xom Appétit', subtitle, actions }: Pr
 }
 
 function NavLinks() {
+  const pathname = usePathname() || '/';
+  const isRecipes = pathname === '/' || pathname.startsWith('/recipes');
+  const isCooks = pathname.startsWith('/cooks');
+
   return (
     <nav className="flex items-center gap-1 bg-zinc-900 rounded-lg p-0.5 border border-zinc-800">
-      <Link
-        href="/"
-        className="px-3 py-1.5 rounded-md text-sm text-zinc-400 hover:text-white hover:bg-zinc-800 transition focus:outline-none focus:ring-2 focus:ring-coral-400/50"
-      >
+      <NavLink href="/" active={isRecipes}>
         Recipes
-      </Link>
-      <Link
-        href="/cooks"
-        className="px-3 py-1.5 rounded-md text-sm text-zinc-400 hover:text-white hover:bg-zinc-800 transition focus:outline-none focus:ring-2 focus:ring-coral-400/50"
-      >
+      </NavLink>
+      <NavLink href="/cooks" active={isCooks}>
         Cooks
-      </Link>
+      </NavLink>
     </nav>
+  );
+}
+
+function NavLink({ href, active, children }: { href: string; active: boolean; children: React.ReactNode }) {
+  const cls = active
+    ? 'bg-zinc-800 text-coral-300'
+    : 'text-zinc-400 hover:text-white hover:bg-zinc-800';
+  return (
+    <Link
+      href={href}
+      aria-current={active ? 'page' : undefined}
+      className={`px-3 py-1.5 rounded-md text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-coral-400/50 ${cls}`}
+    >
+      {children}
+    </Link>
   );
 }
 
@@ -78,7 +80,7 @@ function UserMenu() {
     return (
       <Link
         href="/auth/sign-in"
-        className="bg-zinc-900 hover:bg-zinc-800 border border-zinc-800 hover:border-coral-500/50 text-zinc-100 px-3 py-2 rounded-lg text-sm font-semibold transition"
+        className="bg-zinc-900 hover:bg-zinc-800 border border-zinc-800 hover:border-coral-500/50 text-zinc-100 px-3 py-1.5 rounded-lg text-sm font-semibold transition"
       >
         Sign in
       </Link>
@@ -86,9 +88,9 @@ function UserMenu() {
   }
 
   const handle = profile?.preferredUsername ?? user.preferredUsername;
-  const label = profile?.displayName?.trim() || handle;
+  const label = profile?.displayName?.trim() || handle || 'You';
   const avatarUrl = profile?.avatarUrl ?? null;
-  const initial = (label || handle).charAt(0);
+  const initial = (label || 'U').charAt(0);
 
   return (
     <div ref={ref} className="relative">
@@ -98,7 +100,7 @@ function UserMenu() {
         aria-haspopup="menu"
         aria-expanded={open}
         aria-label={`Account menu for ${label}`}
-        className="flex items-center gap-2 bg-zinc-900 hover:bg-zinc-800 border border-zinc-800 hover:border-coral-500/50 text-zinc-100 px-2.5 py-1.5 rounded-lg text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-coral-400/40"
+        className="flex items-center gap-2 bg-zinc-900 hover:bg-zinc-800 border border-zinc-800 hover:border-coral-500/50 text-zinc-100 px-2 py-1 rounded-lg text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-coral-400/40"
       >
         <span className="h-7 w-7 rounded-full overflow-hidden bg-zinc-800 grid place-items-center shrink-0">
           {avatarUrl ? (
@@ -110,7 +112,7 @@ function UserMenu() {
             </span>
           )}
         </span>
-        <span className="max-w-[8rem] truncate">{label}</span>
+        <span className="max-w-[8rem] truncate hidden sm:inline">{label}</span>
         <span className="text-zinc-500" aria-hidden="true">
           ▾
         </span>
@@ -123,7 +125,7 @@ function UserMenu() {
         >
           <div className="px-3 py-2 border-b border-zinc-800">
             <div className="text-sm font-semibold text-zinc-100 truncate">{label}</div>
-            <div className="text-xs text-zinc-500 truncate">@{handle}</div>
+            {handle && <div className="text-xs text-zinc-500 truncate">@{handle}</div>}
           </div>
           <Link
             role="menuitem"


### PR DESCRIPTION
## Three UX fixes from feedback

1. **'Welcome to Flavortown' was blinking.** During the auth/data transition, the SWR key briefly became null and `recipes` momentarily empty, which flashed the EmptyState. Add an explicit `dataReady` guard so the kitchen-warmup spinner stays visible until we actually have data.

2. **'+ New recipe' moved out of the global top bar.** It now lives in the recipes page body alongside the page title — the top bar was the wrong place for a page-level action.

3. **Header re-mounted on every nav.** Each page rendered its own `<Header />` with different subtitle/actions, so navigating Recipes ↔ Cooks shifted the layout. Refactored:
   - New `AppShell` client wrapper mounts `Header` ONCE at the layout level (suppressed on `/auth/*` so sign-in/up keep their AuthShell card)
   - Header simplified to brand + nav + user menu only
   - Active nav state via `aria-current` + coral-300 text
   - Each page now renders its own sub-header (h2 + count + page actions) in its body

Net: global chrome stays put, no flicker, CTAs live where they belong.