### PR TITLE
feat(profile): avatar picker — stock colors, recent uploads, device

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -40,7 +40,6 @@ export default function ProfilePage() {
         profile={profile}
         onClose={() => setEditOpen(false)}
         onSave={edit}
-        onUploadAvatar={uploadAvatar}
       />
     </div>
   );

--- a/src/components/AvatarPicker.tsx
+++ b/src/components/AvatarPicker.tsx
@@ -1,0 +1,173 @@
+'use client';
+import { useRef, useState } from 'react';
+import { AVATAR_SWATCHES, APP_DEFAULT_AVATAR_COLOR } from '@/lib/avatar-swatches';
+import { usersApi } from '@/lib/users';
+import StockAvatar from './StockAvatar';
+
+type Choice =
+  | { kind: 'photo'; url: string }
+  | { kind: 'stock'; color: string };
+
+interface Props {
+  /** Currently-saved avatar URL (mutually exclusive with stockColor). */
+  avatarUrl: string | null;
+  /** Currently-saved stock-avatar color (mutually exclusive with avatarUrl). */
+  stockColor: string | null;
+  /** Past uploaded URLs the user can re-select. Most recent first. */
+  history: string[];
+  /** Pending in-flight changes that haven't been saved yet. */
+  pending: Choice | null;
+  /** Fired when the user picks a new option (photo from history, stock color, or fresh upload). */
+  onChange: (choice: Choice) => void;
+}
+
+const ACCEPT = 'image/png,image/jpeg,image/webp';
+
+/**
+ * Three-row avatar picker:
+ *  1. Big preview of the current/pending pick
+ *  2. Stock — 8 colored swatches of the brand X-eyes mark
+ *  3. Recent — past uploads (history)
+ *  4. Upload-from-device button
+ *
+ * Pending state is local — the parent EditProfileModal saves it via
+ * usersApi.edit() on form submit. Direct device uploads happen via
+ * presigned PUT, then the new URL flows back through onChange.
+ */
+export default function AvatarPicker({
+  avatarUrl,
+  stockColor,
+  history,
+  pending,
+  onChange,
+}: Props) {
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  // What's actually rendered in the preview right now — pending choice
+  // wins over saved.
+  const activePhoto = pending?.kind === 'photo' ? pending.url : pending ? null : avatarUrl;
+  const activeStock = pending?.kind === 'stock' ? pending.color : pending ? null : stockColor;
+
+  async function onFileSelected(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploadError(null);
+    setUploading(true);
+    try {
+      const url = await usersApi.uploadAvatar(file);
+      onChange({ kind: 'photo', url });
+    } catch (err) {
+      setUploadError(err instanceof Error ? err.message : 'Upload failed.');
+    } finally {
+      setUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Preview */}
+      <div className="flex items-center gap-4">
+        <div className="h-24 w-24 rounded-full overflow-hidden bg-zinc-800 border border-zinc-700 grid place-items-center shrink-0">
+          {activePhoto ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={activePhoto} alt="" className="h-full w-full object-cover" />
+          ) : (
+            <StockAvatar color={activeStock || APP_DEFAULT_AVATAR_COLOR} size={88} />
+          )}
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm text-zinc-300">
+            {activePhoto
+              ? 'Custom photo'
+              : activeStock
+                ? 'Stock avatar'
+                : 'Default avatar'}
+          </p>
+          <p className="text-xs text-zinc-500 mt-0.5">
+            Pick a color, reuse a past photo, or upload a new one.
+          </p>
+        </div>
+      </div>
+
+      {/* Upload */}
+      <div>
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={uploading}
+          className="w-full text-sm bg-zinc-900 hover:bg-zinc-800 border border-zinc-800 hover:border-coral-500/50 rounded-lg px-3 py-2 text-zinc-100 transition disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-coral-400/50"
+        >
+          {uploading ? 'Uploading…' : '+ Upload from device'}
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={ACCEPT}
+          className="hidden"
+          onChange={onFileSelected}
+        />
+        {uploadError && (
+          <p role="alert" className="text-xs text-coral-300 mt-1">
+            {uploadError}
+          </p>
+        )}
+      </div>
+
+      {/* Stock swatches */}
+      <div>
+        <div className="text-xs uppercase tracking-wider text-zinc-500 mb-2">Stock</div>
+        <div className="grid grid-cols-4 sm:grid-cols-8 gap-2">
+          {AVATAR_SWATCHES.map((sw) => {
+            const selected = activeStock === sw.hex && !activePhoto;
+            return (
+              <button
+                key={sw.hex}
+                type="button"
+                onClick={() => onChange({ kind: 'stock', color: sw.hex })}
+                aria-label={`Stock avatar ${sw.label}`}
+                aria-pressed={selected}
+                className={`group relative h-14 w-full rounded-lg overflow-hidden bg-zinc-900 border transition focus:outline-none focus:ring-2 focus:ring-coral-400/50 ${
+                  selected ? 'border-coral-400 ring-1 ring-coral-400/40' : 'border-zinc-800 hover:border-zinc-600'
+                }`}
+              >
+                <span className="grid place-items-center h-full w-full">
+                  <StockAvatar color={sw.hex} size={44} />
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Recent uploads */}
+      {history.length > 0 && (
+        <div>
+          <div className="text-xs uppercase tracking-wider text-zinc-500 mb-2">Recent</div>
+          <div className="grid grid-cols-6 gap-2">
+            {history.map((url) => {
+              const selected = activePhoto === url;
+              return (
+                <button
+                  key={url}
+                  type="button"
+                  onClick={() => onChange({ kind: 'photo', url })}
+                  aria-label="Reuse this photo"
+                  aria-pressed={selected}
+                  className={`relative h-14 w-full rounded-lg overflow-hidden bg-zinc-800 border transition focus:outline-none focus:ring-2 focus:ring-coral-400/50 ${
+                    selected ? 'border-coral-400 ring-1 ring-coral-400/40' : 'border-zinc-800 hover:border-zinc-600'
+                  }`}
+                >
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img src={url} alt="" className="h-full w-full object-cover" />
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/EditProfileModal.tsx
+++ b/src/components/EditProfileModal.tsx
@@ -1,6 +1,7 @@
 'use client';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import Modal from './Modal';
+import AvatarPicker from './AvatarPicker';
 import {
   EditProfileFields,
   ProfileVisibility,
@@ -12,11 +13,8 @@ interface Props {
   profile: UserProfile;
   onClose: () => void;
   onSave: (fields: EditProfileFields) => Promise<UserProfile>;
-  onUploadAvatar: (file: File) => Promise<UserProfile>;
 }
 
-const ACCEPTED_TYPES = 'image/png,image/jpeg,image/webp';
-const MAX_AVATAR_BYTES = 5 * 1024 * 1024; // 5 MB
 const DISPLAY_NAME_MIN = 1;
 const DISPLAY_NAME_MAX = 50;
 
@@ -25,71 +23,46 @@ const inputCls =
 const labelCls =
   'block text-xs font-semibold uppercase tracking-wider text-zinc-400 mb-1.5';
 
+type AvatarChoice =
+  | { kind: 'photo'; url: string }
+  | { kind: 'stock'; color: string };
+
 export default function EditProfileModal({
   open,
   profile,
   onClose,
   onSave,
-  onUploadAvatar,
 }: Props) {
   const [displayName, setDisplayName] = useState(profile.displayName);
   const [visibility, setVisibility] = useState<ProfileVisibility>(
     profile.profileVisibility,
   );
-  const [pendingFile, setPendingFile] = useState<File | null>(null);
-  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [pendingAvatar, setPendingAvatar] = useState<AvatarChoice | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // Reset form whenever a new profile is loaded into the modal (e.g. user
-  // opens it, edits, closes, opens again).
   useEffect(() => {
     if (!open) return;
     setDisplayName(profile.displayName);
     setVisibility(profile.profileVisibility);
-    setPendingFile(null);
-    setPreviewUrl(null);
+    setPendingAvatar(null);
     setError(null);
   }, [open, profile.displayName, profile.profileVisibility]);
-
-  // Manage object URL lifecycle so we don't leak blobs.
-  useEffect(() => {
-    if (!pendingFile) {
-      setPreviewUrl(null);
-      return;
-    }
-    const url = URL.createObjectURL(pendingFile);
-    setPreviewUrl(url);
-    return () => URL.revokeObjectURL(url);
-  }, [pendingFile]);
 
   const trimmedName = displayName.trim();
   const nameValid =
     trimmedName.length >= DISPLAY_NAME_MIN &&
     trimmedName.length <= DISPLAY_NAME_MAX;
 
+  const avatarChanged =
+    pendingAvatar !== null &&
+    !(pendingAvatar.kind === 'photo' && pendingAvatar.url === profile.avatarUrl) &&
+    !(pendingAvatar.kind === 'stock' && pendingAvatar.color === profile.avatarStockColor);
+
   const dirty =
     trimmedName !== profile.displayName ||
     visibility !== profile.profileVisibility ||
-    !!pendingFile;
-
-  const handleFile = (file: File | null) => {
-    setError(null);
-    if (!file) {
-      setPendingFile(null);
-      return;
-    }
-    if (!['image/png', 'image/jpeg', 'image/webp'].includes(file.type)) {
-      setError('Avatar must be a PNG, JPEG, or WebP.');
-      return;
-    }
-    if (file.size > MAX_AVATAR_BYTES) {
-      setError('Avatar must be 5 MB or smaller.');
-      return;
-    }
-    setPendingFile(file);
-  };
+    avatarChanged;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -97,19 +70,18 @@ export default function EditProfileModal({
     setSubmitting(true);
     setError(null);
     try {
-      // Avatar first so the final edit reflects the new URL atomically.
-      if (pendingFile) {
-        await onUploadAvatar(pendingFile);
-      }
-
       const fields: EditProfileFields = {};
       if (trimmedName !== profile.displayName) fields.displayName = trimmedName;
       if (visibility !== profile.profileVisibility)
         fields.profileVisibility = visibility;
-
-      if (Object.keys(fields).length > 0) {
-        await onSave(fields);
+      if (pendingAvatar?.kind === 'photo') {
+        fields.avatarUrl = pendingAvatar.url;
+        fields.avatarStockColor = null;
+      } else if (pendingAvatar?.kind === 'stock') {
+        fields.avatarStockColor = pendingAvatar.color;
+        fields.avatarUrl = null;
       }
+      if (Object.keys(fields).length > 0) await onSave(fields);
       onClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Save failed');
@@ -118,60 +90,18 @@ export default function EditProfileModal({
     }
   };
 
-  const avatarShown = previewUrl ?? profile.avatarUrl ?? null;
-
   return (
     <Modal open={open} onClose={onClose} title="Edit profile">
       <form onSubmit={handleSubmit} className="space-y-5">
         <div>
           <span className={labelCls}>Avatar</span>
-          <div className="flex items-center gap-4">
-            <div className="h-20 w-20 rounded-full overflow-hidden border border-zinc-700 bg-zinc-800 grid place-items-center">
-              {avatarShown ? (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img
-                  src={avatarShown}
-                  alt=""
-                  className="h-full w-full object-cover"
-                />
-              ) : (
-                <span
-                  className="text-xl font-black uppercase text-white bg-gradient-to-br from-coral-500 to-flame-500 h-full w-full grid place-items-center"
-                  aria-hidden="true"
-                >
-                  {profile.preferredUsername.charAt(0)}
-                </span>
-              )}
-            </div>
-            <div className="flex flex-col gap-2">
-              <button
-                type="button"
-                onClick={() => fileInputRef.current?.click()}
-                className="bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 hover:border-coral-500/50 text-zinc-100 px-3 py-1.5 rounded-md text-xs font-semibold uppercase tracking-wider transition focus:outline-none focus:ring-2 focus:ring-coral-400/40"
-              >
-                {avatarShown ? 'Change' : 'Upload'}
-              </button>
-              {pendingFile && (
-                <button
-                  type="button"
-                  onClick={() => handleFile(null)}
-                  className="text-xs text-zinc-400 hover:text-coral-300 transition"
-                >
-                  Cancel selection
-                </button>
-              )}
-              <p className="text-[11px] text-zinc-500">
-                PNG, JPEG, or WebP. Max 5 MB.
-              </p>
-            </div>
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept={ACCEPTED_TYPES}
-              className="sr-only"
-              onChange={(e) => handleFile(e.target.files?.[0] ?? null)}
-            />
-          </div>
+          <AvatarPicker
+            avatarUrl={profile.avatarUrl}
+            stockColor={profile.avatarStockColor}
+            history={profile.avatarHistory ?? []}
+            pending={pendingAvatar}
+            onChange={setPendingAvatar}
+          />
         </div>
 
         <div>

--- a/src/components/StockAvatar.tsx
+++ b/src/components/StockAvatar.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+interface Props {
+  /** Hex color for the X eyes + mouth. Silhouette is always black. */
+  color: string;
+  /** Visual size in pixels (square). */
+  size?: number;
+  className?: string;
+}
+
+/**
+ * Renders /user-icon.svg as an inline SVG so the eyes/mouth (which use
+ * `currentColor`) inherit the chosen color. Using <img> would lock to
+ * black because external SVGs don't pick up CSS color from the page.
+ */
+export default function StockAvatar({ color, size = 64, className = '' }: Props) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 500 500"
+      width={size}
+      height={size}
+      style={{ color, width: size, height: size }}
+      className={className}
+      aria-hidden="true"
+    >
+      <g fill="#000">
+        <circle cx={250} cy={170} r={115} />
+        <path d="M 250,300 C 130,300 60,365 60,445 L 60,500 L 440,500 L 440,445 C 440,365 370,300 250,300 Z" />
+      </g>
+      <rect x={155} y={146} width={80} height={18} rx={9} fill="currentColor" transform="rotate(45 195 155)" />
+      <rect x={155} y={146} width={80} height={18} rx={9} fill="currentColor" transform="rotate(-45 195 155)" />
+      <rect x={265} y={146} width={80} height={18} rx={9} fill="currentColor" transform="rotate(45 305 155)" />
+      <rect x={265} y={146} width={80} height={18} rx={9} fill="currentColor" transform="rotate(-45 305 155)" />
+      <rect x={185} y={221} width={130} height={18} rx={9} fill="currentColor" />
+    </svg>
+  );
+}

--- a/src/lib/avatar-swatches.ts
+++ b/src/lib/avatar-swatches.ts
@@ -1,0 +1,27 @@
+/**
+ * Stock-avatar color swatches. Each swatch maps to one Xomware app's
+ * primary brand color. Users pick a swatch in the EditProfileModal and
+ * the stock SVG (/user-icon.svg) is tinted to that hex via CSS color.
+ *
+ * Order matters — flows left-to-right in the picker grid. Coral lives
+ * first since this is Xom Appétit; the local app default is highlighted
+ * in the UI but every swatch is selectable so a user can pick any vibe.
+ */
+export interface AvatarSwatch {
+  hex: string;
+  label: string;
+}
+
+export const AVATAR_SWATCHES: readonly AvatarSwatch[] = [
+  { hex: '#ff6b6b', label: 'Coral' },        // Xom Appétit
+  { hex: '#00b4d8', label: 'Cyan' },         // Xomware
+  { hex: '#9c0abf', label: 'Purple' },       // Xomify
+  { hex: '#ff6b35', label: 'Orange' },       // XomCloud
+  { hex: '#00ffab', label: 'Mint' },         // Xomper
+  { hex: '#34C759', label: 'Green' },        // XomFit
+  { hex: '#C8102E', label: 'Crimson' },      // Sun God Derby
+  { hex: '#FFB800', label: 'Amber' },        // Float
+];
+
+/** App-default for Xom Appétit — the highlighted swatch when no stock color set. */
+export const APP_DEFAULT_AVATAR_COLOR = '#ff6b6b';

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -13,6 +13,10 @@ export interface UserProfile {
   preferredUsername: string;
   displayName: string;
   avatarUrl: string | null;
+  /** Hex color (`#rrggbb`) for the stock SVG avatar; null when using uploaded photo or app default. */
+  avatarStockColor: string | null;
+  /** Recently-used avatar URLs (most recent first, capped at 6). */
+  avatarHistory: string[];
   profileVisibility: ProfileVisibility;
   createdAt: string;
 }
@@ -23,12 +27,14 @@ export interface PublicUserProfile {
   preferredUsername: string;
   displayName: string;
   avatarUrl: string | null;
+  avatarStockColor: string | null;
   profileVisibility: ProfileVisibility;
 }
 
 export interface EditProfileFields {
   displayName?: string;
   avatarUrl?: string | null;
+  avatarStockColor?: string | null;
   profileVisibility?: ProfileVisibility;
 }
 


### PR DESCRIPTION
EditProfileModal now uses an AvatarPicker with three sections:

1. **Stock** — 8 colored variants of the brand X-eyes mark, one per Xomware app primary (coral, cyan, purple, orange, mint, green, crimson, amber)
2. **Recent** — past uploaded URLs from `avatarHistory` (auto-tracked by the backend), click to re-select
3. **Upload from device** — file input → presigned PUT → URL flows back into the picker

Stock-color and uploaded-photo are mutually exclusive at both API and UI; picking one nulls the other on save.

Pairs with **xomware-infrastructure#42** (users-edit lambda support for `avatarStockColor` + auto-tracked `avatarHistory`).