### PR TITLE
feat(social): /discover + /u/view public profile + Discover nav

### DIFF
--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -1,0 +1,56 @@
+'use client';
+import Link from 'next/link';
+import { useRequireAuth } from '@/lib/auth-context';
+import { usePublicRecipes } from '@/lib/hooks';
+import { RecipeCard } from '@/components/RecipeCard';
+import Loader from '@/components/Loader';
+
+export default function DiscoverPage() {
+  const { isAuthenticated, isLoading: authLoading } = useRequireAuth();
+  const { recipes, isLoading } = usePublicRecipes();
+  const dataReady = isAuthenticated && !isLoading;
+
+  return (
+    <main className="max-w-6xl mx-auto px-4 py-6 space-y-6">
+      <div>
+        <h2 className="font-display text-2xl font-black uppercase tracking-wide">Discover</h2>
+        <p className="text-sm text-zinc-400 mt-1">
+          <span className="text-coral-400 font-semibold">{recipes.length}</span>{' '}
+          public {recipes.length === 1 ? 'recipe' : 'recipes'} from the kitchen
+        </p>
+      </div>
+
+      {!dataReady || authLoading ? (
+        <Loader caption="finding recipes…" />
+      ) : recipes.length === 0 ? (
+        <EmptyDiscover />
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {recipes.map((r) => (
+            <RecipeCard key={r.recipeId} recipe={r} />
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}
+
+function EmptyDiscover() {
+  return (
+    <div className="text-center py-16 border border-dashed border-zinc-800 rounded-xl">
+      <div className="text-5xl mb-3">🍽️</div>
+      <h3 className="font-display text-2xl font-black uppercase tracking-wide">
+        Nothing public yet
+      </h3>
+      <p className="text-zinc-400 text-sm mt-2 max-w-sm mx-auto">
+        When chefs publish recipes, they show up here. Be the first.
+      </p>
+      <Link
+        href="/recipes/new"
+        className="mt-5 inline-block bg-gradient-to-r from-coral-500 to-coral-400 hover:from-coral-400 hover:to-coral-300 text-white font-bold uppercase tracking-wider px-6 py-2.5 rounded-lg transition shadow-lg shadow-coral-500/20 focus:outline-none focus:ring-2 focus:ring-coral-400/50"
+      >
+        Add a recipe
+      </Link>
+    </div>
+  );
+}

--- a/src/app/u/view/page.tsx
+++ b/src/app/u/view/page.tsx
@@ -1,0 +1,120 @@
+'use client';
+import { Suspense, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+import { useRequireAuth, useAuth } from '@/lib/auth-context';
+import { useUserRecipes } from '@/lib/hooks';
+import { usersApi, PublicUserProfile } from '@/lib/users';
+import { RecipeCard } from '@/components/RecipeCard';
+import Loader from '@/components/Loader';
+
+export default function UserPage() {
+  return (
+    <Suspense fallback={<Loader fullscreen caption="loading profile…" />}>
+      <UserPageInner />
+    </Suspense>
+  );
+}
+
+function UserPageInner() {
+  const params = useSearchParams();
+  const handle = params.get('handle')?.trim().toLowerCase() || null;
+  const { isAuthenticated, isLoading: authLoading } = useRequireAuth();
+  const { user } = useAuth();
+
+  const [profile, setProfile] = useState<PublicUserProfile | null>(null);
+  const [profileError, setProfileError] = useState<string | null>(null);
+  const [profileLoading, setProfileLoading] = useState(true);
+
+  useEffect(() => {
+    if (!isAuthenticated || !handle) return;
+    setProfileLoading(true);
+    setProfileError(null);
+    usersApi
+      .getByHandle(handle)
+      .then((p) => setProfile(p))
+      .catch((err: Error) => setProfileError(err.message || 'User not found'))
+      .finally(() => setProfileLoading(false));
+  }, [isAuthenticated, handle]);
+
+  const { recipes, isLoading: recipesLoading } = useUserRecipes(profile?.userId ?? null);
+
+  if (authLoading) return <Loader fullscreen />;
+  if (!handle) {
+    return (
+      <main className="max-w-3xl mx-auto px-4 py-12 text-center">
+        <p className="text-zinc-400">No handle in URL. Try <code className="text-coral-300">/u/view?handle=someone</code>.</p>
+      </main>
+    );
+  }
+  if (profileLoading) return <Loader caption="loading profile…" />;
+  if (profileError || !profile) {
+    return (
+      <main className="max-w-3xl mx-auto px-4 py-12 text-center space-y-3">
+        <h2 className="font-display text-2xl font-black uppercase">No such chef</h2>
+        <p className="text-zinc-400 text-sm">
+          Couldn&apos;t find <span className="text-coral-300">@{handle}</span>.
+        </p>
+        <Link href="/discover" className="inline-block text-coral-400 hover:text-coral-300 text-sm font-semibold">
+          ← Back to Discover
+        </Link>
+      </main>
+    );
+  }
+
+  const isPrivate = profile.profileVisibility === 'private';
+  const isSelf = user?.sub === profile.userId;
+  const initial = (profile.displayName || profile.preferredUsername || '?').charAt(0).toUpperCase();
+
+  return (
+    <main className="max-w-6xl mx-auto px-4 py-6 space-y-6">
+      <header className="flex items-center gap-4">
+        <div className="h-20 w-20 rounded-full overflow-hidden bg-zinc-800 border border-zinc-700 grid place-items-center shrink-0">
+          {profile.avatarUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={profile.avatarUrl} alt="" className="h-full w-full object-cover" />
+          ) : (
+            <span className="h-full w-full grid place-items-center bg-gradient-to-br from-coral-500 to-flame-500 text-white text-2xl font-black uppercase">
+              {initial}
+            </span>
+          )}
+        </div>
+        <div className="min-w-0">
+          <h1 className="font-display text-2xl font-black tracking-tight truncate">
+            {profile.displayName || `@${profile.preferredUsername}`}
+          </h1>
+          {profile.preferredUsername && (
+            <p className="text-sm text-zinc-400">@{profile.preferredUsername}</p>
+          )}
+        </div>
+      </header>
+
+      {isPrivate && !isSelf ? (
+        <div className="text-center py-16 border border-dashed border-zinc-800 rounded-xl">
+          <div className="text-5xl mb-3">🔒</div>
+          <h3 className="font-display text-xl font-black uppercase tracking-wide">Private profile</h3>
+          <p className="text-zinc-400 text-sm mt-2">
+            This kitchen is closed to outsiders.
+          </p>
+        </div>
+      ) : (
+        <section className="space-y-4">
+          <h2 className="font-display text-lg font-black uppercase tracking-wide">
+            {isSelf ? 'Your recipes' : 'Public recipes'}
+          </h2>
+          {recipesLoading ? (
+            <Loader caption="loading recipes…" />
+          ) : recipes.length === 0 ? (
+            <p className="text-zinc-500 italic text-sm">No public recipes yet.</p>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {recipes.map((r) => (
+                <RecipeCard key={r.recipeId} recipe={r} />
+              ))}
+            </div>
+          )}
+        </section>
+      )}
+    </main>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -29,12 +29,16 @@ export default function Header() {
 function NavLinks() {
   const pathname = usePathname() || '/';
   const isRecipes = pathname === '/' || pathname.startsWith('/recipes');
+  const isDiscover = pathname.startsWith('/discover') || pathname.startsWith('/u/');
   const isCooks = pathname.startsWith('/cooks');
 
   return (
     <nav className="flex items-center gap-1 bg-zinc-900 rounded-lg p-0.5 border border-zinc-800">
       <NavLink href="/" active={isRecipes}>
         Recipes
+      </NavLink>
+      <NavLink href="/discover" active={isDiscover}>
+        Discover
       </NavLink>
       <NavLink href="/cooks" active={isCooks}>
         Cooks

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -68,8 +68,18 @@ export interface RateRecipeResult {
   ratingCount: number;
 }
 
+export interface RecipesPublicPage {
+  items: Recipe[];
+  nextCursor: string | null;
+}
+
 export const recipesApi = {
-  list: (): Promise<Recipe[]> => apiPost<Recipe[]>('/recipes/list'),
+  /** Caller's own recipes (default), or another user's public recipes when `authorUserId` is set. */
+  list: (authorUserId?: string): Promise<Recipe[]> =>
+    apiPost<Recipe[]>('/recipes/list', authorUserId ? { authorUserId } : undefined),
+  /** Global feed of `privacy = 'public'` recipes, newest first. */
+  listPublic: (opts?: { limit?: number; cursor?: string }): Promise<RecipesPublicPage> =>
+    apiPost<RecipesPublicPage>('/recipes/list-public', opts ?? {}),
   create: (body: CreateRecipeInput): Promise<Recipe> =>
     apiPost<Recipe>('/recipes/create', body),
   get: (recipeId: string): Promise<Recipe> =>

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -21,7 +21,7 @@ export function useRecipes() {
   const { isAuthenticated } = useAuth();
   const { data, error, isLoading } = useSWR(
     isAuthenticated ? RECIPES_KEY : null,
-    recipesApi.list,
+    () => recipesApi.list(),
   );
 
   return {
@@ -44,6 +44,31 @@ export function useRecipes() {
       mutate(RECIPES_KEY);
     },
   };
+}
+
+/** Public recipes feed — anyone signed in can read this. */
+export function usePublicRecipes() {
+  const { isAuthenticated } = useAuth();
+  const { data, error, isLoading } = useSWR(
+    isAuthenticated ? 'recipes:public' : null,
+    () => recipesApi.listPublic({ limit: 50 }),
+  );
+  return {
+    recipes: data?.items ?? [],
+    nextCursor: data?.nextCursor ?? null,
+    isLoading: isAuthenticated ? isLoading : false,
+    error,
+  };
+}
+
+/** Recipes by another user (filtered to public on the server). */
+export function useUserRecipes(authorUserId: string | null) {
+  const { isAuthenticated } = useAuth();
+  const key = authorUserId && isAuthenticated ? ['user-recipes', authorUserId] as const : null;
+  const { data, error, isLoading } = useSWR(key, () =>
+    authorUserId ? recipesApi.list(authorUserId) : Promise.reject(new Error('no id')),
+  );
+  return { recipes: data ?? [], isLoading, error };
 }
 
 export function useRecipe(recipeId: string | null) {


### PR DESCRIPTION
Foundation of the social side of Xom Appétit.

- **`/discover`** — global feed of public recipes via `usePublicRecipes()`. Same RecipeCard grid as home.
- **`/u/view?handle=X`** — public profile by handle. Resolves via xomware `/users/get-by-handle`, then queries `/recipes/list` with `authorUserId` for that user's public recipes. Honors `profileVisibility = 'private'` (locked card for non-self).
- **Header** gains a Discover tab; active state covers `/u/*` too.

**Pairs with**: xomappetit-backend + xomappetit-infrastructure (matching feature branches).

Friends system + feed are the next chunk.