### PR TITLE
feat(social): friends UI — /friends, feed home, add-friend on profiles

### DIFF
--- a/src/app/friends/page.tsx
+++ b/src/app/friends/page.tsx
@@ -1,0 +1,247 @@
+'use client';
+import { FormEvent, useState } from 'react';
+import Link from 'next/link';
+import { useRequireAuth } from '@/lib/auth-context';
+import { useFriends } from '@/lib/hooks';
+import { usersApi } from '@/lib/users';
+import Loader from '@/components/Loader';
+
+const HANDLE_REGEX = /^[a-z0-9_]{3,20}$/;
+
+export default function FriendsPage() {
+  const { isAuthenticated, isLoading: authLoading } = useRequireAuth();
+  const {
+    friends,
+    incomingPending,
+    outgoingPending,
+    isLoading,
+    refresh,
+    addFriend,
+    respond,
+    remove,
+  } = useFriends();
+
+  const [handle, setHandle] = useState('');
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [info, setInfo] = useState<string | null>(null);
+
+  const dataReady = isAuthenticated && !isLoading;
+
+  const submitAdd = async (e: FormEvent) => {
+    e.preventDefault();
+    const cleaned = handle.trim().toLowerCase();
+    setError(null);
+    setInfo(null);
+    if (!HANDLE_REGEX.test(cleaned)) {
+      setError('Handle must be 3–20 lowercase letters, numbers, or underscores.');
+      return;
+    }
+    setPending(true);
+    try {
+      const target = await usersApi.getByHandle(cleaned);
+      const res = await addFriend(target.userId);
+      if (res.alreadyFriends) setInfo(`@${cleaned} is already your friend.`);
+      else if (res.alreadyRequested) setInfo(`Already sent a request to @${cleaned}.`);
+      else if (res.mutualRequest) setInfo(`Friends with @${cleaned}! (mutual request)`);
+      else setInfo(`Request sent to @${cleaned}.`);
+      setHandle('');
+      refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Couldn’t add friend.');
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <main className="max-w-3xl mx-auto px-4 py-6 space-y-8">
+      <div>
+        <h2 className="font-display text-2xl font-black uppercase tracking-wide">Friends</h2>
+        <p className="text-sm text-zinc-400 mt-1">
+          <span className="text-coral-400 font-semibold">{friends.length}</span>{' '}
+          {friends.length === 1 ? 'friend' : 'friends'}
+          {incomingPending.length > 0 && (
+            <span className="ml-2 text-coral-300">
+              · {incomingPending.length} pending {incomingPending.length === 1 ? 'request' : 'requests'}
+            </span>
+          )}
+        </p>
+      </div>
+
+      {/* Add */}
+      <section className="bg-zinc-900/60 border border-zinc-800 rounded-xl p-4">
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-400 mb-2">
+          Add a friend
+        </h3>
+        <form onSubmit={submitAdd} className="flex gap-2">
+          <div className="relative flex-1">
+            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500">@</span>
+            <input
+              type="text"
+              autoCapitalize="off"
+              autoCorrect="off"
+              spellCheck={false}
+              value={handle}
+              onChange={(e) => setHandle(e.target.value)}
+              placeholder="someone"
+              className="w-full bg-zinc-950 border border-zinc-800 rounded-lg pl-7 pr-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-coral-400/40 focus:border-coral-400"
+              disabled={pending}
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={pending || !handle.trim()}
+            className="bg-gradient-to-r from-coral-500 to-coral-400 hover:from-coral-400 hover:to-coral-300 disabled:opacity-50 text-white px-4 py-2 rounded-lg text-sm font-bold uppercase tracking-wide transition focus:outline-none focus:ring-2 focus:ring-coral-400/50"
+          >
+            {pending ? 'Sending…' : 'Send'}
+          </button>
+        </form>
+        {error && <p role="alert" className="text-xs text-coral-300 mt-2">{error}</p>}
+        {info && <p className="text-xs text-emerald-300 mt-2">{info}</p>}
+      </section>
+
+      {!dataReady || authLoading ? (
+        <Loader caption="loading friends…" />
+      ) : (
+        <>
+          {/* Incoming requests */}
+          {incomingPending.length > 0 && (
+            <section className="space-y-2">
+              <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-400">
+                Incoming requests
+              </h3>
+              <ul className="space-y-2">
+                {incomingPending.map((req) => (
+                  <UserRow
+                    key={req.userId}
+                    userId={req.userId}
+                    timestamp={req.requestedAt}
+                    timestampLabel="requested"
+                    actions={
+                      <>
+                        <SmallBtn primary onClick={() => respond(req.userId, 'accept')}>
+                          Accept
+                        </SmallBtn>
+                        <SmallBtn onClick={() => respond(req.userId, 'decline')}>
+                          Decline
+                        </SmallBtn>
+                      </>
+                    }
+                  />
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {/* Friends */}
+          <section className="space-y-2">
+            <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-400">
+              Friends
+            </h3>
+            {friends.length === 0 ? (
+              <p className="text-sm text-zinc-500 italic py-4">
+                No friends yet. Add one above or browse <Link href="/discover" className="text-coral-400 hover:text-coral-300">Discover</Link>.
+              </p>
+            ) : (
+              <ul className="space-y-2">
+                {friends.map((f) => (
+                  <UserRow
+                    key={f.userId}
+                    userId={f.userId}
+                    timestamp={f.since}
+                    timestampLabel="friends since"
+                    actions={
+                      <SmallBtn onClick={() => remove(f.userId)}>Remove</SmallBtn>
+                    }
+                  />
+                ))}
+              </ul>
+            )}
+          </section>
+
+          {/* Outgoing pending */}
+          {outgoingPending.length > 0 && (
+            <section className="space-y-2">
+              <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-400">
+                Pending (you sent)
+              </h3>
+              <ul className="space-y-2">
+                {outgoingPending.map((req) => (
+                  <UserRow
+                    key={req.userId}
+                    userId={req.userId}
+                    timestamp={req.requestedAt}
+                    timestampLabel="sent"
+                    actions={
+                      <SmallBtn onClick={() => remove(req.userId)}>Cancel</SmallBtn>
+                    }
+                  />
+                ))}
+              </ul>
+            </section>
+          )}
+        </>
+      )}
+    </main>
+  );
+}
+
+function UserRow({
+  userId,
+  timestamp,
+  timestampLabel,
+  actions,
+}: {
+  userId: string;
+  timestamp?: string;
+  timestampLabel?: string;
+  actions: React.ReactNode;
+}) {
+  // Truncate the userId for display until we resolve handles. Click goes
+  // nowhere yet — handle/profile lookup by userId would need a new endpoint.
+  return (
+    <li className="flex items-center justify-between gap-3 bg-zinc-900/60 border border-zinc-800 rounded-lg px-3 py-2">
+      <div className="min-w-0 flex items-center gap-3">
+        <div className="h-9 w-9 rounded-full bg-gradient-to-br from-coral-500 to-flame-500 grid place-items-center text-white font-black text-sm shrink-0">
+          {userId.charAt(0).toUpperCase()}
+        </div>
+        <div className="min-w-0">
+          <code className="text-sm font-mono text-zinc-300 truncate block">
+            {userId.slice(0, 8)}…
+          </code>
+          {timestamp && (
+            <p className="text-[11px] text-zinc-500">
+              {timestampLabel} {new Date(timestamp).toLocaleDateString()}
+            </p>
+          )}
+        </div>
+      </div>
+      <div className="flex gap-2 shrink-0">{actions}</div>
+    </li>
+  );
+}
+
+function SmallBtn({
+  children,
+  primary,
+  onClick,
+}: {
+  children: React.ReactNode;
+  primary?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={
+        primary
+          ? 'bg-gradient-to-r from-coral-500 to-coral-400 hover:from-coral-400 hover:to-coral-300 text-white text-xs font-bold uppercase tracking-wide px-3 py-1.5 rounded-md transition focus:outline-none focus:ring-2 focus:ring-coral-400/50'
+          : 'bg-zinc-800 hover:bg-zinc-700 border border-zinc-700 hover:border-coral-500/50 text-zinc-200 text-xs font-semibold uppercase tracking-wide px-3 py-1.5 rounded-md transition focus:outline-none focus:ring-2 focus:ring-coral-400/40'
+      }
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,45 +1,58 @@
 'use client';
 import Link from 'next/link';
 import { useRequireAuth } from '@/lib/auth-context';
-import { useRecipes } from '@/lib/hooks';
+import { useFeed } from '@/lib/hooks';
 import { RecipeCard } from '@/components/RecipeCard';
 import { MASCOTS, mascotFor } from '@/components/Mascot';
 import Loader from '@/components/Loader';
 
-export default function Home() {
+/**
+ * Home = Feed. Recipes from caller + accepted friends, newest first.
+ *
+ * Empty states are tiered:
+ *   - 0 friends + 0 recipes: nudge to add a recipe and find friends
+ *   - 0 friends + some recipes (yours): show them and prompt to find friends
+ *   - has friends but feed empty: prompt to publish a recipe
+ */
+export default function Feed() {
   const { isAuthenticated, isLoading: authLoading } = useRequireAuth();
-  const { recipes, isLoading } = useRecipes();
-
-  // While auth is settling OR we haven't done the first data load yet,
-  // show the kitchen-warmup spinner. Don't fall through to EmptyState
-  // mid-transition — that's what made "Welcome to Flavortown" blink.
+  const { items, friendCount, isLoading } = useFeed();
   const dataReady = isAuthenticated && !isLoading;
 
   return (
     <main className="max-w-6xl mx-auto px-4 py-6 space-y-6">
       <div className="flex items-end justify-between gap-4 flex-wrap">
         <div>
-          <h2 className="font-display text-2xl font-black uppercase tracking-wide">Recipes</h2>
+          <h2 className="font-display text-2xl font-black uppercase tracking-wide">Feed</h2>
           <p className="text-sm text-zinc-400 mt-1">
-            <span className="text-coral-400 font-semibold">{recipes.length}</span>{' '}
-            {recipes.length === 1 ? 'recipe' : 'recipes'}
+            {friendCount > 0 ? (
+              <>
+                from you and{' '}
+                <span className="text-coral-400 font-semibold">{friendCount}</span>{' '}
+                {friendCount === 1 ? 'friend' : 'friends'}
+              </>
+            ) : (
+              'just your kitchen for now'
+            )}
           </p>
         </div>
-        <Link
-          href="/recipes/new"
-          className="bg-gradient-to-r from-coral-500 to-coral-400 hover:from-coral-400 hover:to-coral-300 text-white px-4 py-2 rounded-lg text-sm font-bold uppercase tracking-wide transition shadow-lg shadow-coral-500/20 focus:outline-none focus:ring-2 focus:ring-coral-400/50"
-        >
-          + New recipe
-        </Link>
+        <div className="flex gap-2">
+          <Link
+            href="/recipes/new"
+            className="bg-gradient-to-r from-coral-500 to-coral-400 hover:from-coral-400 hover:to-coral-300 text-white px-4 py-2 rounded-lg text-sm font-bold uppercase tracking-wide transition shadow-lg shadow-coral-500/20 focus:outline-none focus:ring-2 focus:ring-coral-400/50"
+          >
+            + New recipe
+          </Link>
+        </div>
       </div>
 
       {!dataReady || authLoading ? (
         <Loader />
-      ) : recipes.length === 0 ? (
-        <EmptyState />
+      ) : items.length === 0 ? (
+        <EmptyFeed friendCount={friendCount} />
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {recipes.map((r) => (
+          {items.map((r) => (
             <RecipeCard key={r.recipeId} recipe={r} />
           ))}
         </div>
@@ -48,23 +61,43 @@ export default function Home() {
   );
 }
 
-function EmptyState() {
-  const mascot = MASCOTS[mascotFor('empty-state')];
+function EmptyFeed({ friendCount }: { friendCount: number }) {
+  const mascot = MASCOTS[mascotFor('empty-feed')];
   return (
     <div className="text-center py-16 border border-dashed border-zinc-800 rounded-xl">
       <div className="text-5xl mb-3">{mascot.emoji}</div>
       <h2 className="font-display text-2xl font-black uppercase tracking-wide">
-        {mascot.caption}
+        {friendCount === 0 ? 'Find your kitchen crew' : 'Quiet in here'}
       </h2>
       <p className="text-zinc-400 text-sm mt-2 max-w-sm mx-auto">
-        No recipes yet. Add your first one — {mascot.name} will judge you accordingly.
+        {friendCount === 0
+          ? 'Add friends to see their cooking, or post your first recipe so they can see yours.'
+          : 'Your friends haven’t posted yet. Add one of your own.'}
       </p>
-      <Link
-        href="/recipes/new"
-        className="mt-5 inline-block bg-gradient-to-r from-coral-500 to-coral-400 hover:from-coral-400 hover:to-coral-300 text-white font-bold uppercase tracking-wider px-6 py-2.5 rounded-lg transition shadow-lg shadow-coral-500/20 focus:outline-none focus:ring-2 focus:ring-coral-400/50"
-      >
-        Add your first recipe
-      </Link>
+      <div className="mt-5 flex gap-2 justify-center flex-wrap">
+        <Link
+          href="/recipes/new"
+          className="bg-gradient-to-r from-coral-500 to-coral-400 hover:from-coral-400 hover:to-coral-300 text-white font-bold uppercase tracking-wider px-5 py-2.5 rounded-lg transition shadow-lg shadow-coral-500/20 focus:outline-none focus:ring-2 focus:ring-coral-400/50"
+        >
+          New recipe
+        </Link>
+        {friendCount === 0 && (
+          <>
+            <Link
+              href="/friends"
+              className="bg-zinc-900 hover:bg-zinc-800 border border-zinc-800 hover:border-coral-500/50 text-zinc-100 font-bold uppercase tracking-wider px-5 py-2.5 rounded-lg transition focus:outline-none focus:ring-2 focus:ring-coral-400/40"
+            >
+              Find friends
+            </Link>
+            <Link
+              href="/discover"
+              className="bg-zinc-900 hover:bg-zinc-800 border border-zinc-800 hover:border-coral-500/50 text-zinc-100 font-bold uppercase tracking-wider px-5 py-2.5 rounded-lg transition focus:outline-none focus:ring-2 focus:ring-coral-400/40"
+            >
+              Discover
+            </Link>
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/app/u/view/page.tsx
+++ b/src/app/u/view/page.tsx
@@ -3,7 +3,7 @@ import { Suspense, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { useRequireAuth, useAuth } from '@/lib/auth-context';
-import { useUserRecipes } from '@/lib/hooks';
+import { useUserRecipes, useFriends } from '@/lib/hooks';
 import { usersApi, PublicUserProfile } from '@/lib/users';
 import { RecipeCard } from '@/components/RecipeCard';
 import Loader from '@/components/Loader';
@@ -79,7 +79,7 @@ function UserPageInner() {
             </span>
           )}
         </div>
-        <div className="min-w-0">
+        <div className="min-w-0 flex-1">
           <h1 className="font-display text-2xl font-black tracking-tight truncate">
             {profile.displayName || `@${profile.preferredUsername}`}
           </h1>
@@ -87,6 +87,7 @@ function UserPageInner() {
             <p className="text-sm text-zinc-400">@{profile.preferredUsername}</p>
           )}
         </div>
+        {!isSelf && <FriendButton targetUserId={profile.userId} />}
       </header>
 
       {isPrivate && !isSelf ? (
@@ -116,5 +117,76 @@ function UserPageInner() {
         </section>
       )}
     </main>
+  );
+}
+
+function FriendButton({ targetUserId }: { targetUserId: string }) {
+  const { friends, incomingPending, outgoingPending, addFriend, respond, remove } = useFriends();
+  const [busy, setBusy] = useState(false);
+
+  const isFriend = friends.some((f) => f.userId === targetUserId);
+  const incoming = incomingPending.find((r) => r.userId === targetUserId);
+  const outgoing = outgoingPending.some((r) => r.userId === targetUserId);
+
+  const wrap = (fn: () => Promise<unknown>) => async () => {
+    setBusy(true);
+    try { await fn(); } finally { setBusy(false); }
+  };
+
+  if (isFriend) {
+    return (
+      <button
+        type="button"
+        onClick={wrap(() => remove(targetUserId))}
+        disabled={busy}
+        className="bg-zinc-900 hover:bg-zinc-800 border border-zinc-800 hover:border-coral-500/50 text-zinc-100 px-4 py-2 rounded-lg text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-coral-400/40 disabled:opacity-50 shrink-0"
+      >
+        ✓ Friends
+      </button>
+    );
+  }
+  if (incoming) {
+    return (
+      <div className="flex gap-2 shrink-0">
+        <button
+          type="button"
+          onClick={wrap(() => respond(targetUserId, 'accept'))}
+          disabled={busy}
+          className="bg-gradient-to-r from-coral-500 to-coral-400 hover:from-coral-400 hover:to-coral-300 text-white px-3 py-2 rounded-lg text-sm font-bold uppercase tracking-wide transition focus:outline-none focus:ring-2 focus:ring-coral-400/50 disabled:opacity-50"
+        >
+          Accept
+        </button>
+        <button
+          type="button"
+          onClick={wrap(() => respond(targetUserId, 'decline'))}
+          disabled={busy}
+          className="bg-zinc-900 hover:bg-zinc-800 border border-zinc-800 text-zinc-300 px-3 py-2 rounded-lg text-sm font-semibold transition disabled:opacity-50"
+        >
+          Decline
+        </button>
+      </div>
+    );
+  }
+  if (outgoing) {
+    return (
+      <button
+        type="button"
+        onClick={wrap(() => remove(targetUserId))}
+        disabled={busy}
+        className="bg-zinc-900 border border-zinc-800 text-zinc-400 px-4 py-2 rounded-lg text-sm font-semibold transition disabled:opacity-50 shrink-0"
+      >
+        Cancel request
+      </button>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={wrap(() => addFriend(targetUserId))}
+      disabled={busy}
+      className="bg-gradient-to-r from-coral-500 to-coral-400 hover:from-coral-400 hover:to-coral-300 text-white px-4 py-2 rounded-lg text-sm font-bold uppercase tracking-wide transition shadow-lg shadow-coral-500/20 focus:outline-none focus:ring-2 focus:ring-coral-400/50 disabled:opacity-50 shrink-0"
+    >
+      + Add friend
+    </button>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -28,17 +28,21 @@ export default function Header() {
 
 function NavLinks() {
   const pathname = usePathname() || '/';
-  const isRecipes = pathname === '/' || pathname.startsWith('/recipes');
+  const isFeed = pathname === '/' || pathname.startsWith('/recipes');
   const isDiscover = pathname.startsWith('/discover') || pathname.startsWith('/u/');
+  const isFriends = pathname.startsWith('/friends');
   const isCooks = pathname.startsWith('/cooks');
 
   return (
     <nav className="flex items-center gap-1 bg-zinc-900 rounded-lg p-0.5 border border-zinc-800">
-      <NavLink href="/" active={isRecipes}>
-        Recipes
+      <NavLink href="/" active={isFeed}>
+        Feed
       </NavLink>
       <NavLink href="/discover" active={isDiscover}>
         Discover
+      </NavLink>
+      <NavLink href="/friends" active={isFriends}>
+        Friends
       </NavLink>
       <NavLink href="/cooks" active={isCooks}>
         Cooks

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -73,6 +73,30 @@ export interface RecipesPublicPage {
   nextCursor: string | null;
 }
 
+export interface FriendsListResponse {
+  friends: { userId: string; since: string }[];
+  incomingPending: { userId: string; requestedAt: string }[];
+  outgoingPending: { userId: string; requestedAt: string }[];
+}
+
+export interface FriendsFeedResponse {
+  items: Recipe[];
+  friendCount: number;
+}
+
+export const friendsApi = {
+  list: (): Promise<FriendsListResponse> =>
+    apiPost<FriendsListResponse>('/friends/list'),
+  add: (friendUserId: string): Promise<{ status: 'pending' | 'accepted'; alreadyFriends?: boolean; alreadyRequested?: boolean; mutualRequest?: boolean }> =>
+    apiPost('/friends/add', { friendUserId }),
+  respond: (friendUserId: string, action: 'accept' | 'decline'): Promise<{ status: 'accepted' | 'declined' }> =>
+    apiPost('/friends/respond', { friendUserId, action }),
+  remove: (friendUserId: string): Promise<{ status: 'removed' }> =>
+    apiPost('/friends/remove', { friendUserId }),
+  feed: (limit = 50): Promise<FriendsFeedResponse> =>
+    apiPost<FriendsFeedResponse>('/friends/feed', { limit }),
+};
+
 export const recipesApi = {
   /** Caller's own recipes (default), or another user's public recipes when `authorUserId` is set. */
   list: (authorUserId?: string): Promise<Recipe[]> =>

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -6,9 +6,13 @@ import {
   LogCookInput,
   commentsApi,
   cooksApi,
+  friendsApi,
   recipesApi,
 } from './api';
 import { useAuth } from './auth-context';
+
+const FRIENDS_KEY = 'friends';
+const FEED_KEY = 'friends:feed';
 
 const RECIPES_KEY = 'recipes';
 const recipeKey = (id: string) => ['recipe', id] as const;
@@ -42,6 +46,56 @@ export function useRecipes() {
     deleteRecipe: async (id: string) => {
       await recipesApi.delete(id);
       mutate(RECIPES_KEY);
+    },
+  };
+}
+
+/** Friends feed — recipes from caller + accepted friends, newest first. */
+export function useFeed() {
+  const { isAuthenticated } = useAuth();
+  const { data, error, isLoading, mutate: mutateFeed } = useSWR(
+    isAuthenticated ? FEED_KEY : null,
+    () => friendsApi.feed(),
+  );
+  return {
+    items: data?.items ?? [],
+    friendCount: data?.friendCount ?? 0,
+    isLoading: isAuthenticated ? isLoading : false,
+    error,
+    refresh: () => mutateFeed(),
+  };
+}
+
+/** All friendship state in one shot, plus mutator helpers. */
+export function useFriends() {
+  const { isAuthenticated } = useAuth();
+  const { data, error, isLoading, mutate: mutateFriends } = useSWR(
+    isAuthenticated ? FRIENDS_KEY : null,
+    () => friendsApi.list(),
+  );
+  return {
+    friends: data?.friends ?? [],
+    incomingPending: data?.incomingPending ?? [],
+    outgoingPending: data?.outgoingPending ?? [],
+    isLoading: isAuthenticated ? isLoading : false,
+    error,
+    refresh: () => mutateFriends(),
+    addFriend: async (friendUserId: string) => {
+      const res = await friendsApi.add(friendUserId);
+      mutate(FRIENDS_KEY);
+      mutate(FEED_KEY);
+      return res;
+    },
+    respond: async (friendUserId: string, action: 'accept' | 'decline') => {
+      const res = await friendsApi.respond(friendUserId, action);
+      mutate(FRIENDS_KEY);
+      mutate(FEED_KEY);
+      return res;
+    },
+    remove: async (friendUserId: string) => {
+      await friendsApi.remove(friendUserId);
+      mutate(FRIENDS_KEY);
+      mutate(FEED_KEY);
     },
   };
 }


### PR DESCRIPTION
Closes the social loop. Three big changes:

- **/friends** — three sections (incoming, current, outgoing) + add-by-handle form. Handle resolves via xomware `get-by-handle` then calls `friends/add`.
- **Home is now the Feed** — `friends-feed` returns recipes from caller + accepted friends. Tiered empty states: no-friends-no-recipes / friends-but-quiet / first-recipe-prompt.
- **`/u/view?handle=X` gets a FriendButton** — not-friend / outgoing-pending / incoming-pending / friend (4 states with correct action).

Header nav becomes **Feed | Discover | Friends | Cooks**. Active state covers nested routes.

Pairs with **xomappetit-backend feat/friends-and-feed** + **xomappetit-infrastructure feat/friends-and-feed**.