### PR TITLE
feat(likes): heart toggle on RecipeCard + recipes/view

### DIFF
--- a/src/app/recipes/view/page.tsx
+++ b/src/app/recipes/view/page.tsx
@@ -7,6 +7,7 @@ import { useRecipe } from '@/lib/hooks';
 import { RecipeForm, RecipeFormValues } from '@/components/RecipeForm';
 import { RecipeComments } from '@/components/RecipeComments';
 import { RatingStars } from '@/components/RatingStars';
+import LikeButton from '@/components/LikeButton';
 import { PrivacyBadge } from '@/components/PrivacyBadge';
 import { Ingredient, ingredientLabel } from '@/types';
 import { recipesApi } from '@/lib/api';
@@ -155,6 +156,22 @@ function RecipeViewInner() {
                   {recipe.proteinSource}
                 </span>
               </>
+            )}
+          </div>
+
+          <div className="flex items-center gap-3 pt-2">
+            <LikeButton
+              recipeId={recipe.recipeId}
+              initialCount={recipe.likeCount ?? 0}
+              initialLiked={recipe.likedByMe ?? false}
+            />
+            <span className="text-xs text-zinc-500">
+              {recipe.cookCount} {recipe.cookCount === 1 ? 'cook' : 'cooks'}
+            </span>
+            {recipe.ratingCount > 0 && (
+              <span className="text-xs text-zinc-500">
+                ★ {recipe.avgRating.toFixed(1)} ({recipe.ratingCount})
+              </span>
             )}
           </div>
 

--- a/src/components/LikeButton.tsx
+++ b/src/components/LikeButton.tsx
@@ -1,0 +1,80 @@
+'use client';
+import { useState } from 'react';
+import { recipesApi } from '@/lib/api';
+
+interface Props {
+  recipeId: string;
+  initialCount?: number;
+  initialLiked?: boolean;
+  /** Compact card-footer style; default is the larger detail-page style. */
+  compact?: boolean;
+  onChange?: (state: { likeCount: number; likedByMe: boolean }) => void;
+}
+
+/**
+ * Heart toggle for a recipe. Optimistic update flips the icon + count
+ * on click, then reconciles with the server response. Failures roll
+ * back and show a transient red border.
+ */
+export default function LikeButton({
+  recipeId,
+  initialCount = 0,
+  initialLiked = false,
+  compact = false,
+  onChange,
+}: Props) {
+  const [count, setCount] = useState(initialCount);
+  const [liked, setLiked] = useState(initialLiked);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState(false);
+
+  const onClick = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (pending) return;
+
+    // Optimistic flip
+    const nextLiked = !liked;
+    const nextCount = Math.max(0, count + (nextLiked ? 1 : -1));
+    setLiked(nextLiked);
+    setCount(nextCount);
+    setError(false);
+    setPending(true);
+
+    try {
+      const res = await recipesApi.like(recipeId);
+      setCount(res.likeCount);
+      setLiked(res.likedByMe);
+      onChange?.({ likeCount: res.likeCount, likedByMe: res.likedByMe });
+    } catch {
+      // Roll back
+      setLiked(liked);
+      setCount(count);
+      setError(true);
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const sizeCls = compact ? 'text-xs px-2 py-1' : 'text-sm px-3 py-1.5';
+  const heart = liked ? '♥' : '♡';
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={liked}
+      aria-label={liked ? 'Unlike recipe' : 'Like recipe'}
+      className={`inline-flex items-center gap-1 rounded-md border transition focus:outline-none focus:ring-2 focus:ring-coral-400/40 ${sizeCls} ${
+        liked
+          ? 'bg-coral-500/15 text-coral-300 border-coral-500/30 hover:bg-coral-500/20'
+          : 'bg-zinc-900 text-zinc-400 border-zinc-800 hover:border-coral-500/30 hover:text-coral-300'
+      } ${error ? 'border-red-500/60' : ''} ${pending ? 'opacity-70' : ''}`}
+    >
+      <span aria-hidden="true" className={liked ? 'text-coral-300' : ''}>
+        {heart}
+      </span>
+      <span className="font-semibold">{count}</span>
+    </button>
+  );
+}

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -2,6 +2,7 @@
 import Link from 'next/link';
 import { Recipe } from '@/types';
 import { PrivacyBadge } from './PrivacyBadge';
+import LikeButton from './LikeButton';
 
 interface Props {
   recipe: Recipe;
@@ -51,31 +52,31 @@ export function RecipeCard({ recipe }: Props) {
         </span>
       )}
 
-      <div className="flex items-center justify-between pt-1 border-t border-zinc-800/60">
-        <div className="text-xs text-zinc-500 flex items-center gap-3">
-          <span>
+      <div className="flex items-center justify-between pt-1 border-t border-zinc-800/60 gap-2">
+        <div className="text-xs text-zinc-500 flex items-center gap-3 min-w-0">
+          <LikeButton
+            recipeId={recipe.recipeId}
+            initialCount={recipe.likeCount ?? 0}
+            initialLiked={recipe.likedByMe ?? false}
+            compact
+          />
+          <span className="truncate">
             <span className="text-zinc-300 font-semibold">{recipe.cookCount}</span>{' '}
             {recipe.cookCount === 1 ? 'cook' : 'cooks'}
           </span>
-          {recipe.ratingCount > 0 ? (
-            <span className="flex items-center gap-1">
+          {recipe.ratingCount > 0 && (
+            <span className="flex items-center gap-1 shrink-0">
               <span className="text-coral-300">★</span>
               <span className="text-zinc-300 font-semibold">
                 {recipe.avgRating.toFixed(1)}
               </span>
-              <span className="text-zinc-600">
-                ({recipe.ratingCount})
-              </span>
             </span>
-          ) : (
-            <span className="text-zinc-600">no ratings yet</span>
           )}
         </div>
         {recipe.authorHandle && (
           <button
             type="button"
             onClick={(e) => {
-              // Stop the parent <Link> from also navigating to the recipe detail.
               e.preventDefault();
               e.stopPropagation();
               window.location.assign(`/u/view?handle=${encodeURIComponent(recipe.authorHandle!)}`);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -114,6 +114,8 @@ export const recipesApi = {
     apiPost<void>('/recipes/delete', { recipeId }),
   rate: (recipeId: string, rating: number): Promise<RateRecipeResult> =>
     apiPost<RateRecipeResult>('/recipes/rate', { recipeId, rating }),
+  like: (recipeId: string): Promise<{ recipeId: string; likeCount: number; likedByMe: boolean }> =>
+    apiPost('/recipes/like', { recipeId }),
 };
 
 export const commentsApi = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,10 @@ export interface Recipe {
   macros: Macros;
   privacy: Privacy;
   cookCount: number;
+  /** Total likes across all users. Denormalized — updated by recipes-like. */
+  likeCount?: number;
+  /** Did the caller like this recipe? Only present on recipes-get / feed responses. */
+  likedByMe?: boolean;
   avgRating: number;
   ratingCount: number;
   createdAt: string;


### PR DESCRIPTION
New `<LikeButton>` component with optimistic flip + rollback on error. Two variants: compact (card footer) and full (detail page hero).

`Recipe` type gains optional `likeCount` + `likedByMe` — populated by recipes-get and friend-feed responses.

Pairs with backend + infra friends-privacy / likes PRs.