### PR TITLE
feat(feed): render cook activity items alongside recipes

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { useRequireAuth } from '@/lib/auth-context';
 import { useFeed } from '@/lib/hooks';
 import { RecipeCard } from '@/components/RecipeCard';
+import { CookActivityCard } from '@/components/CookActivityCard';
 import { MASCOTS, mascotFor } from '@/components/Mascot';
 import Loader from '@/components/Loader';
 
@@ -52,9 +53,20 @@ export default function Feed() {
         <EmptyFeed friendCount={friendCount} />
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {items.map((r) => (
-            <RecipeCard key={r.recipeId} recipe={r} />
-          ))}
+          {items.map((item) => {
+            if (item.type === 'cook') {
+              return (
+                <CookActivityCard
+                  key={`cook-${item.cook.cookId}`}
+                  cook={item.cook}
+                  recipe={item.recipe}
+                />
+              );
+            }
+            return (
+              <RecipeCard key={`recipe-${item.recipe.recipeId}`} recipe={item.recipe} />
+            );
+          })}
         </div>
       )}
     </main>

--- a/src/components/CookActivityCard.tsx
+++ b/src/components/CookActivityCard.tsx
@@ -1,0 +1,70 @@
+'use client';
+import Link from 'next/link';
+import { Cook, Recipe } from '@/types';
+
+interface Props {
+  cook: Cook;
+  recipe: Recipe;
+}
+
+/**
+ * Feed item shape for "X cooked Recipe Y on Z". Distinct visual from
+ * RecipeCard so the user reads the feed as activity, not catalog.
+ *
+ * Tap goes to the cook detail (`/cooks/view`), with a secondary link
+ * to the recipe itself in the body.
+ */
+export function CookActivityCard({ cook, recipe }: Props) {
+  const date = new Date(cook.cookedAt).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+  const chefHandle = recipe.authorHandle; // best signal we have for "who cooked"
+
+  return (
+    <Link
+      href={`/cooks/view?id=${encodeURIComponent(cook.cookId)}`}
+      className="group block bg-zinc-900/60 border-l-2 border-coral-500/50 border-t border-r border-b border-zinc-800 hover:border-coral-500/50 rounded-xl p-4 transition focus:outline-none focus:ring-2 focus:ring-coral-400/50"
+    >
+      <div className="flex items-start gap-3">
+        <div className="h-10 w-10 rounded-full bg-gradient-to-br from-coral-500 to-flame-500 grid place-items-center text-white text-xl shrink-0">
+          🔥
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-xs text-zinc-500 uppercase tracking-wider font-semibold mb-0.5">
+            Cook session · {date}
+          </p>
+          <h3 className="font-bold text-base text-zinc-100 truncate group-hover:text-coral-300 transition">
+            {chefHandle ? (
+              <>
+                <span className="text-coral-400">@{chefHandle}</span>{' '}
+                <span className="text-zinc-400 font-normal">cooked</span>{' '}
+                {recipe.name}
+              </>
+            ) : (
+              <>Someone cooked {recipe.name}</>
+            )}
+          </h3>
+          {cook.notes && (
+            <p className="text-sm text-zinc-300 mt-1 line-clamp-2">{cook.notes}</p>
+          )}
+          <div className="text-xs text-zinc-500 flex items-center gap-3 mt-2">
+            {cook.rating != null && (
+              <span className="flex items-center gap-1">
+                <span className="text-coral-300">★</span>
+                <span className="text-zinc-300 font-semibold">{cook.rating}/5</span>
+              </span>
+            )}
+            {cook.diners.length > 0 && (
+              <span>
+                <span className="text-zinc-300 font-semibold">{cook.diners.length}</span>{' '}
+                {cook.diners.length === 1 ? 'diner' : 'diners'}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -79,8 +79,12 @@ export interface FriendsListResponse {
   outgoingPending: { userId: string; requestedAt: string }[];
 }
 
+export type FeedItem =
+  | { type: 'recipe'; recipe: Recipe }
+  | { type: 'cook'; cook: Cook; recipe: Recipe };
+
 export interface FriendsFeedResponse {
-  items: Recipe[];
+  items: FeedItem[];
   friendCount: number;
 }
 

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -50,7 +50,7 @@ export function useRecipes() {
   };
 }
 
-/** Friends feed — recipes from caller + accepted friends, newest first. */
+/** Friends feed — mixed recipes + cooks from caller + accepted friends. */
 export function useFeed() {
   const { isAuthenticated } = useAuth();
   const { data, error, isLoading, mutate: mutateFeed } = useSWR(


### PR DESCRIPTION
New `<CookActivityCard>` for cook items. Distinct from RecipeCard — coral left border, '🔥 Cook session · date' eyebrow, '@chef cooked Recipe Y' headline, rating + diner count. Tap → `/cooks/view`.

`FeedItem` is now a discriminated union; the home feed switches on type.