### PR TITLE
feat(social): real names + avatars on cards + friends list

### DIFF
--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -2,12 +2,14 @@
 import Link from 'next/link';
 import { useRequireAuth } from '@/lib/auth-context';
 import { usePublicRecipes } from '@/lib/hooks';
+import { useUsersById } from '@/lib/use-users-by-id';
 import { RecipeCard } from '@/components/RecipeCard';
 import Loader from '@/components/Loader';
 
 export default function DiscoverPage() {
   const { isAuthenticated, isLoading: authLoading } = useRequireAuth();
   const { recipes, isLoading } = usePublicRecipes();
+  const { map: users } = useUsersById(recipes.map((r) => r.authorUserId));
   const dataReady = isAuthenticated && !isLoading;
 
   return (
@@ -27,7 +29,7 @@ export default function DiscoverPage() {
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {recipes.map((r) => (
-            <RecipeCard key={r.recipeId} recipe={r} />
+            <RecipeCard key={r.recipeId} recipe={r} author={users.get(r.authorUserId)} />
           ))}
         </div>
       )}

--- a/src/app/friends/page.tsx
+++ b/src/app/friends/page.tsx
@@ -3,7 +3,8 @@ import { FormEvent, useState } from 'react';
 import Link from 'next/link';
 import { useRequireAuth } from '@/lib/auth-context';
 import { useFriends } from '@/lib/hooks';
-import { usersApi } from '@/lib/users';
+import { useUsersById } from '@/lib/use-users-by-id';
+import { usersApi, PublicUserProfile } from '@/lib/users';
 import Loader from '@/components/Loader';
 
 const HANDLE_REGEX = /^[a-z0-9_]{3,20}$/;
@@ -25,6 +26,15 @@ export default function FriendsPage() {
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [info, setInfo] = useState<string | null>(null);
+
+  // Resolve every userId on this page to a public profile in one
+  // round trip — friends, incoming, outgoing.
+  const allIds = [
+    ...friends.map((f) => f.userId),
+    ...incomingPending.map((r) => r.userId),
+    ...outgoingPending.map((r) => r.userId),
+  ];
+  const { map: users } = useUsersById(allIds);
 
   const dataReady = isAuthenticated && !isLoading;
 
@@ -116,6 +126,7 @@ export default function FriendsPage() {
                   <UserRow
                     key={req.userId}
                     userId={req.userId}
+                    profile={users.get(req.userId)}
                     timestamp={req.requestedAt}
                     timestampLabel="requested"
                     actions={
@@ -149,6 +160,7 @@ export default function FriendsPage() {
                   <UserRow
                     key={f.userId}
                     userId={f.userId}
+                    profile={users.get(f.userId)}
                     timestamp={f.since}
                     timestampLabel="friends since"
                     actions={
@@ -171,6 +183,7 @@ export default function FriendsPage() {
                   <UserRow
                     key={req.userId}
                     userId={req.userId}
+                    profile={users.get(req.userId)}
                     timestamp={req.requestedAt}
                     timestampLabel="sent"
                     actions={
@@ -189,34 +202,57 @@ export default function FriendsPage() {
 
 function UserRow({
   userId,
+  profile,
   timestamp,
   timestampLabel,
   actions,
 }: {
   userId: string;
+  profile: PublicUserProfile | undefined;
   timestamp?: string;
   timestampLabel?: string;
   actions: React.ReactNode;
 }) {
-  // Truncate the userId for display until we resolve handles. Click goes
-  // nowhere yet — handle/profile lookup by userId would need a new endpoint.
+  const handle = profile?.preferredUsername;
+  const name = profile?.displayName;
+  const avatarUrl = profile?.avatarUrl;
+  const initial = (name || handle || '?').charAt(0).toUpperCase();
+  const headline = name || (handle ? `@${handle}` : `${userId.slice(0, 8)}…`);
+  const subline = name && handle ? `@${handle}` : null;
+
+  const inner = (
+    <div className="min-w-0 flex items-center gap-3 flex-1">
+      <div className="h-9 w-9 rounded-full overflow-hidden bg-zinc-800 grid place-items-center shrink-0">
+        {avatarUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={avatarUrl} alt="" className="h-full w-full object-cover" />
+        ) : (
+          <span className="h-full w-full grid place-items-center bg-gradient-to-br from-coral-500 to-flame-500 text-white font-black text-sm">
+            {initial}
+          </span>
+        )}
+      </div>
+      <div className="min-w-0">
+        <p className="text-sm font-semibold text-zinc-100 truncate">{headline}</p>
+        {subline && <p className="text-[11px] text-zinc-500">{subline}</p>}
+        {timestamp && (
+          <p className="text-[11px] text-zinc-500">
+            {timestampLabel} {new Date(timestamp).toLocaleDateString()}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+
   return (
     <li className="flex items-center justify-between gap-3 bg-zinc-900/60 border border-zinc-800 rounded-lg px-3 py-2">
-      <div className="min-w-0 flex items-center gap-3">
-        <div className="h-9 w-9 rounded-full bg-gradient-to-br from-coral-500 to-flame-500 grid place-items-center text-white font-black text-sm shrink-0">
-          {userId.charAt(0).toUpperCase()}
-        </div>
-        <div className="min-w-0">
-          <code className="text-sm font-mono text-zinc-300 truncate block">
-            {userId.slice(0, 8)}…
-          </code>
-          {timestamp && (
-            <p className="text-[11px] text-zinc-500">
-              {timestampLabel} {new Date(timestamp).toLocaleDateString()}
-            </p>
-          )}
-        </div>
-      </div>
+      {handle ? (
+        <Link href={`/u/view?handle=${encodeURIComponent(handle)}`} className="contents">
+          {inner}
+        </Link>
+      ) : (
+        inner
+      )}
       <div className="flex gap-2 shrink-0">{actions}</div>
     </li>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 import Link from 'next/link';
 import { useRequireAuth } from '@/lib/auth-context';
 import { useFeed } from '@/lib/hooks';
+import { useUsersById } from '@/lib/use-users-by-id';
 import { RecipeCard } from '@/components/RecipeCard';
 import { CookActivityCard } from '@/components/CookActivityCard';
 import { MASCOTS, mascotFor } from '@/components/Mascot';
@@ -19,6 +20,15 @@ export default function Feed() {
   const { isAuthenticated, isLoading: authLoading } = useRequireAuth();
   const { items, friendCount, isLoading } = useFeed();
   const dataReady = isAuthenticated && !isLoading;
+
+  // Collect every userId we'll need to render (recipe authors + cook chefs)
+  // and resolve them in a single round trip via /users/batch-get.
+  const userIds = items.flatMap((item) =>
+    item.type === 'cook'
+      ? [item.recipe.authorUserId, ...item.cook.chefs]
+      : [item.recipe.authorUserId],
+  );
+  const { map: users } = useUsersById(userIds);
 
   return (
     <main className="max-w-6xl mx-auto px-4 py-6 space-y-6">
@@ -55,16 +65,22 @@ export default function Feed() {
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {items.map((item) => {
             if (item.type === 'cook') {
+              const chef = users.get(item.cook.chefs[0]) || users.get(item.recipe.authorUserId);
               return (
                 <CookActivityCard
                   key={`cook-${item.cook.cookId}`}
                   cook={item.cook}
                   recipe={item.recipe}
+                  chef={chef}
                 />
               );
             }
             return (
-              <RecipeCard key={`recipe-${item.recipe.recipeId}`} recipe={item.recipe} />
+              <RecipeCard
+                key={`recipe-${item.recipe.recipeId}`}
+                recipe={item.recipe}
+                author={users.get(item.recipe.authorUserId)}
+              />
             );
           })}
         </div>

--- a/src/components/CookActivityCard.tsx
+++ b/src/components/CookActivityCard.tsx
@@ -1,10 +1,13 @@
 'use client';
 import Link from 'next/link';
 import { Cook, Recipe } from '@/types';
+import { PublicUserProfile } from '@/lib/users';
 
 interface Props {
   cook: Cook;
   recipe: Recipe;
+  /** Profile of the cook's chef (the person who logged the cook). */
+  chef?: PublicUserProfile | null;
 }
 
 /**
@@ -14,13 +17,16 @@ interface Props {
  * Tap goes to the cook detail (`/cooks/view`), with a secondary link
  * to the recipe itself in the body.
  */
-export function CookActivityCard({ cook, recipe }: Props) {
+export function CookActivityCard({ cook, recipe, chef }: Props) {
   const date = new Date(cook.cookedAt).toLocaleDateString(undefined, {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
   });
-  const chefHandle = recipe.authorHandle; // best signal we have for "who cooked"
+  const chefHandle = chef?.preferredUsername || recipe.authorHandle;
+  const chefName = chef?.displayName;
+  const chefAvatar = chef?.avatarUrl;
+  const chefInitial = (chefName || chefHandle || '?').charAt(0).toUpperCase();
 
   return (
     <Link
@@ -28,8 +34,15 @@ export function CookActivityCard({ cook, recipe }: Props) {
       className="group block bg-zinc-900/60 border-l-2 border-coral-500/50 border-t border-r border-b border-zinc-800 hover:border-coral-500/50 rounded-xl p-4 transition focus:outline-none focus:ring-2 focus:ring-coral-400/50"
     >
       <div className="flex items-start gap-3">
-        <div className="h-10 w-10 rounded-full bg-gradient-to-br from-coral-500 to-flame-500 grid place-items-center text-white text-xl shrink-0">
-          🔥
+        <div className="h-10 w-10 rounded-full overflow-hidden bg-zinc-800 border border-zinc-700 grid place-items-center text-white text-xl shrink-0">
+          {chefAvatar ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={chefAvatar} alt="" className="h-full w-full object-cover" />
+          ) : (
+            <span className="h-full w-full grid place-items-center bg-gradient-to-br from-coral-500 to-flame-500 text-sm font-black">
+              {chefInitial}
+            </span>
+          )}
         </div>
         <div className="min-w-0 flex-1">
           <p className="text-xs text-zinc-500 uppercase tracking-wider font-semibold mb-0.5">
@@ -38,7 +51,7 @@ export function CookActivityCard({ cook, recipe }: Props) {
           <h3 className="font-bold text-base text-zinc-100 truncate group-hover:text-coral-300 transition">
             {chefHandle ? (
               <>
-                <span className="text-coral-400">@{chefHandle}</span>{' '}
+                <span className="text-coral-400">{chefName || `@${chefHandle}`}</span>{' '}
                 <span className="text-zinc-400 font-normal">cooked</span>{' '}
                 {recipe.name}
               </>

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -1,11 +1,15 @@
 'use client';
 import Link from 'next/link';
 import { Recipe } from '@/types';
+import { PublicUserProfile } from '@/lib/users';
 import { PrivacyBadge } from './PrivacyBadge';
 import LikeButton from './LikeButton';
 
 interface Props {
   recipe: Recipe;
+  /** Public profile of the recipe author, when resolved. Card renders
+   *  a fallback (`@handle` or "a chef") when not provided yet. */
+  author?: PublicUserProfile | null;
 }
 
 function diffColor(d: string) {
@@ -16,7 +20,11 @@ function diffColor(d: string) {
     : 'text-coral-400';
 }
 
-export function RecipeCard({ recipe }: Props) {
+export function RecipeCard({ recipe, author }: Props) {
+  const handle = author?.preferredUsername ?? recipe.authorHandle ?? null;
+  const name = author?.displayName ?? null;
+  const avatarUrl = author?.avatarUrl ?? null;
+  const initial = (name || handle || '?').charAt(0).toUpperCase();
   return (
     <Link
       href={`/recipes/view?id=${encodeURIComponent(recipe.recipeId)}`}
@@ -73,17 +81,28 @@ export function RecipeCard({ recipe }: Props) {
             </span>
           )}
         </div>
-        {recipe.authorHandle && (
+        {handle && (
           <button
             type="button"
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
-              window.location.assign(`/u/view?handle=${encodeURIComponent(recipe.authorHandle!)}`);
+              window.location.assign(`/u/view?handle=${encodeURIComponent(handle)}`);
             }}
-            className="text-xs text-zinc-500 hover:text-coral-300 transition shrink-0"
+            className="flex items-center gap-1.5 text-xs text-zinc-400 hover:text-coral-300 transition shrink-0 min-w-0"
+            title={name || `@${handle}`}
           >
-            @{recipe.authorHandle}
+            <span className="h-5 w-5 rounded-full overflow-hidden bg-zinc-800 grid place-items-center shrink-0">
+              {avatarUrl ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={avatarUrl} alt="" className="h-full w-full object-cover" />
+              ) : (
+                <span className="text-[9px] font-black text-white bg-gradient-to-br from-coral-500 to-flame-500 h-full w-full grid place-items-center">
+                  {initial}
+                </span>
+              )}
+            </span>
+            <span className="truncate max-w-[6rem]">{name || `@${handle}`}</span>
           </button>
         )}
       </div>

--- a/src/lib/use-users-by-id.ts
+++ b/src/lib/use-users-by-id.ts
@@ -1,0 +1,41 @@
+'use client';
+import useSWR from 'swr';
+import { usersApi, PublicUserProfile } from './users';
+import { useAuth } from './auth-context';
+
+/**
+ * Resolve a list of Cognito subs to public profile slices, with SWR
+ * caching keyed by the sorted, joined id list. Components pass in
+ * whatever userIds they have on the screen (feed authors, friend
+ * row userIds, etc.) and get back a Map<userId, profile> they can
+ * pluck from at render time.
+ *
+ * Filters falsy/duplicate ids upfront so callers don't have to.
+ */
+export function useUsersById(userIds: (string | null | undefined)[]) {
+  const { isAuthenticated } = useAuth();
+  const ids = [...new Set(userIds.filter((id): id is string => !!id))].sort();
+  const key = isAuthenticated && ids.length > 0 ? ['users:batch-get', ids.join(',')] : null;
+  const { data, error, isLoading } = useSWR(
+    key,
+    () => usersApi.batchGet(ids),
+    { revalidateOnFocus: false, dedupingInterval: 60_000 },
+  );
+
+  const map = new Map<string, PublicUserProfile>();
+  for (const u of data ?? []) map.set(u.userId, u);
+
+  return { map, isLoading: isAuthenticated ? isLoading : false, error };
+}
+
+/**
+ * Compose a display label from a public profile, falling back through
+ * displayName -> @handle -> email-style userId stub. Mirrors the same
+ * order Header's `userLabel` getter uses.
+ */
+export function userLabel(p: PublicUserProfile | undefined | null): string {
+  if (!p) return 'someone';
+  if (p.displayName?.trim()) return p.displayName.trim();
+  if (p.preferredUsername) return `@${p.preferredUsername}`;
+  return 'a chef';
+}

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -111,6 +111,20 @@ export const usersApi = {
     apiPost<PresignAvatarResponse>('/users/presign-avatar', { contentType }),
 
   /**
+   * Look up multiple users by sub at once. Used to enrich feed/discover
+   * recipe cards with the author's display name + avatar in a single
+   * round trip per page load. Returns the public slice only — no email
+   * etc.
+   */
+  batchGet: async (userIds: string[]): Promise<PublicUserProfile[]> => {
+    if (userIds.length === 0) return [];
+    const res = await apiPost<{ users: PublicUserProfile[] }>('/users/batch-get', {
+      userIds,
+    });
+    return res.users;
+  },
+
+  /**
    * Full upload flow: ask the API for a presigned PUT, push the raw file body
    * directly to S3, and return the CDN URL. Callers persist `finalUrl` via
    * `usersApi.edit({ avatarUrl })`.


### PR DESCRIPTION
Wires the new `/users/batch-get` endpoint into Feed, Discover, and Friends. Recipe cards and cook-activity cards now render the author's display name + avatar (or @handle fallback). Friends rows show real headlines + avatars + clickable links to `/u/view`.

`useUsersById([ids])` is a single batch fetch per page, SWR-cached and deduped 60s.

Pairs with **xomware-infrastructure#43** (the batch-get endpoint).