### PR TITLE
feat(notifications): bell icon + /notifications inbox

### DIFF
--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -1,0 +1,171 @@
+'use client';
+import Link from 'next/link';
+import { useRequireAuth } from '@/lib/auth-context';
+import { useNotifications } from '@/lib/hooks';
+import { useUsersById, userLabel } from '@/lib/use-users-by-id';
+import type { Notification } from '@/lib/api';
+import Loader from '@/components/Loader';
+
+export default function NotificationsPage() {
+  const { isAuthenticated, isLoading: authLoading } = useRequireAuth();
+  const { items, unreadCount, isLoading, markRead, markAllRead } = useNotifications();
+  const { map: users } = useUsersById(items.map((n) => n.actorUserId));
+  const dataReady = isAuthenticated && !isLoading;
+
+  return (
+    <main className="max-w-3xl mx-auto px-4 py-6 space-y-4">
+      <div className="flex items-end justify-between gap-4 flex-wrap">
+        <div>
+          <h2 className="font-display text-2xl font-black uppercase tracking-wide">
+            Notifications
+          </h2>
+          <p className="text-sm text-zinc-400 mt-1">
+            {unreadCount > 0 ? (
+              <>
+                <span className="text-coral-400 font-semibold">{unreadCount}</span> unread
+              </>
+            ) : (
+              'all caught up'
+            )}
+          </p>
+        </div>
+        {unreadCount > 0 && (
+          <button
+            type="button"
+            onClick={() => markAllRead()}
+            className="text-sm text-zinc-400 hover:text-coral-300 underline-offset-2 hover:underline transition"
+          >
+            Mark all read
+          </button>
+        )}
+      </div>
+
+      {!dataReady || authLoading ? (
+        <Loader caption="loading…" />
+      ) : items.length === 0 ? (
+        <div className="text-center py-16 border border-dashed border-zinc-800 rounded-xl">
+          <div className="text-5xl mb-3">🔔</div>
+          <p className="text-zinc-400 text-sm">
+            Nothing yet. Like a recipe or send a friend request to make some noise.
+          </p>
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {items.map((n) => (
+            <NotificationRow
+              key={n.sortKey}
+              notif={n}
+              actor={users.get(n.actorUserId)}
+              onMarkRead={() => markRead(n.sortKey)}
+            />
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}
+
+function NotificationRow({
+  notif,
+  actor,
+  onMarkRead,
+}: {
+  notif: Notification;
+  actor: ReturnType<typeof useUsersById>['map'] extends Map<string, infer V> ? V | undefined : never;
+  onMarkRead: () => void;
+}) {
+  const actorName = userLabel(actor);
+  const actorHandle = actor?.preferredUsername;
+  const recipeName = notif.meta?.recipeName;
+  const time = relativeTime(notif.createdAt);
+
+  let body: React.ReactNode = null;
+  let href: string = '#';
+
+  switch (notif.type) {
+    case 'friend_request':
+      body = <><strong>{actorName}</strong> sent you a friend request</>;
+      href = '/friends';
+      break;
+    case 'friend_accept':
+      body = <><strong>{actorName}</strong> accepted your friend request</>;
+      href = actorHandle ? `/u/view?handle=${encodeURIComponent(actorHandle)}` : '/friends';
+      break;
+    case 'recipe_liked':
+      body = (
+        <>
+          <strong>{actorName}</strong> liked your recipe
+          {recipeName && <> <span className="text-coral-300">{recipeName}</span></>}
+        </>
+      );
+      href = `/recipes/view?id=${encodeURIComponent(notif.refId)}`;
+      break;
+    case 'comment_added':
+      body = (
+        <>
+          <strong>{actorName}</strong> commented on{' '}
+          {notif.refType === 'recipe' ? 'your recipe' : 'a cook'}
+          {recipeName && <> <span className="text-coral-300">{recipeName}</span></>}
+        </>
+      );
+      href =
+        notif.refType === 'recipe'
+          ? `/recipes/view?id=${encodeURIComponent(notif.refId)}`
+          : `/cooks/view?id=${encodeURIComponent(notif.refId)}`;
+      break;
+    default:
+      body = <>Something happened</>;
+  }
+
+  const initial = (actorName || '?').charAt(0).toUpperCase();
+  const avatarUrl = actor?.avatarUrl ?? null;
+
+  return (
+    <li
+      className={`flex items-start gap-3 rounded-lg p-3 border transition ${
+        notif.read
+          ? 'bg-zinc-900/40 border-zinc-800'
+          : 'bg-zinc-900/80 border-coral-500/30'
+      }`}
+    >
+      <div className="h-9 w-9 rounded-full overflow-hidden bg-zinc-800 grid place-items-center shrink-0">
+        {avatarUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={avatarUrl} alt="" className="h-full w-full object-cover" />
+        ) : (
+          <span className="h-full w-full grid place-items-center bg-gradient-to-br from-coral-500 to-flame-500 text-white font-black text-sm">
+            {initial}
+          </span>
+        )}
+      </div>
+      <div className="flex-1 min-w-0">
+        <Link href={href} onClick={() => !notif.read && onMarkRead()} className="block">
+          <p className="text-sm text-zinc-200">{body}</p>
+          <p className="text-[11px] text-zinc-500 mt-0.5">{time}</p>
+        </Link>
+      </div>
+      {!notif.read && (
+        <button
+          type="button"
+          onClick={onMarkRead}
+          aria-label="Mark as read"
+          className="text-[11px] text-zinc-500 hover:text-coral-300 transition shrink-0"
+        >
+          Mark read
+        </button>
+      )}
+    </li>
+  );
+}
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const min = Math.round(diff / 60_000);
+  if (min < 1) return 'just now';
+  if (min < 60) return `${min}m ago`;
+  const hrs = Math.round(min / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.round(hrs / 24);
+  if (days < 30) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString();
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useAuth } from '@/lib/auth-context';
 import { useProfile } from '@/lib/use-profile';
-import { useFriends } from '@/lib/hooks';
+import { useFriends, useNotifications } from '@/lib/hooks';
 import Brand from './Brand';
 
 export default function Header() {
@@ -20,6 +20,7 @@ export default function Header() {
         </Link>
         <div className="flex items-center gap-2">
           <NavLinks />
+          <NotificationsBell />
           <UserMenu />
         </div>
       </div>
@@ -77,6 +78,40 @@ function NavLink({ href, active, badge, children }: { href: string; active: bool
           {badge > 9 ? '9+' : badge}
         </span>
       ) : null}
+    </Link>
+  );
+}
+
+function NotificationsBell() {
+  const pathname = usePathname() || '/';
+  const isActive = pathname.startsWith('/notifications');
+  const { unreadCount } = useNotifications();
+
+  const cls = isActive
+    ? 'bg-zinc-800 text-coral-300'
+    : 'text-zinc-400 hover:text-white hover:bg-zinc-800';
+
+  return (
+    <Link
+      href="/notifications"
+      aria-label={`Notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ''}`}
+      className={`relative inline-flex items-center justify-center h-9 w-9 rounded-md transition focus:outline-none focus:ring-2 focus:ring-coral-400/50 ${cls}`}
+    >
+      {/* Bell icon */}
+      <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" aria-hidden="true">
+        <path
+          d="M12 22a2 2 0 0 0 2-2h-4a2 2 0 0 0 2 2zm6-6V11a6 6 0 0 0-5-5.91V4a1 1 0 1 0-2 0v1.09A6 6 0 0 0 6 11v5l-2 2v1h16v-1l-2-2z"
+          fill="currentColor"
+        />
+      </svg>
+      {unreadCount > 0 && (
+        <span
+          className="absolute top-0 right-0 min-w-[1rem] h-4 px-1 rounded-full bg-coral-500 text-[10px] leading-4 font-bold text-white text-center"
+          aria-hidden="true"
+        >
+          {unreadCount > 9 ? '9+' : unreadCount}
+        </span>
+      )}
     </Link>
   );
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -176,3 +176,37 @@ export const cookCommentsApi = {
   delete: (cookId: string, commentId: string): Promise<void> =>
     apiPost<void>('/cooks/comment-delete', { cookId, commentId }),
 };
+
+export type NotificationType =
+  | 'friend_request'
+  | 'friend_accept'
+  | 'recipe_liked'
+  | 'comment_added';
+
+export interface Notification {
+  userId: string;
+  sortKey: string;
+  notifId: string;
+  type: NotificationType;
+  actorUserId: string;
+  refType: 'recipe' | 'cook' | 'friend';
+  refId: string;
+  meta: { recipeName?: string } | null;
+  read: boolean;
+  createdAt: string;
+}
+
+export interface NotificationsListResponse {
+  items: Notification[];
+  nextCursor: string | null;
+  unreadInPage: number;
+}
+
+export const notificationsApi = {
+  list: (opts?: { limit?: number; cursor?: string }): Promise<NotificationsListResponse> =>
+    apiPost<NotificationsListResponse>('/notifications/list', opts ?? {}),
+  markRead: (sortKey: string): Promise<{ updated: number }> =>
+    apiPost('/notifications/mark-read', { sortKey }),
+  markAllRead: (): Promise<{ updated: number }> =>
+    apiPost('/notifications/mark-read', { all: true }),
+};

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -8,12 +8,14 @@ import {
   cookCommentsApi,
   cooksApi,
   friendsApi,
+  notificationsApi,
   recipesApi,
 } from './api';
 import { useAuth } from './auth-context';
 
 const FRIENDS_KEY = 'friends';
 const FEED_KEY = 'friends:feed';
+const NOTIFICATIONS_KEY = 'notifications';
 
 const RECIPES_KEY = 'recipes';
 const recipeKey = (id: string) => ['recipe', id] as const;
@@ -65,6 +67,59 @@ export function useFeed() {
     isLoading: isAuthenticated ? isLoading : false,
     error,
     refresh: () => mutateFeed(),
+  };
+}
+
+/** Notifications inbox + unread count + mutators. */
+export function useNotifications() {
+  const { isAuthenticated } = useAuth();
+  const { data, error, isLoading, mutate: mutateNotifs } = useSWR(
+    isAuthenticated ? NOTIFICATIONS_KEY : null,
+    () => notificationsApi.list({ limit: 50 }),
+    {
+      // Poll every 30s so the bell badge stays fresh without a websocket.
+      refreshInterval: 30_000,
+      revalidateOnFocus: true,
+    },
+  );
+  const items = data?.items ?? [];
+  const unreadCount = items.filter((n) => !n.read).length;
+
+  return {
+    items,
+    unreadCount,
+    isLoading: isAuthenticated ? isLoading : false,
+    error,
+    refresh: () => mutateNotifs(),
+    markRead: async (sortKey: string) => {
+      // Optimistic flip
+      mutateNotifs(
+        (prev) => prev && {
+          ...prev,
+          items: prev.items.map((n) => (n.sortKey === sortKey ? { ...n, read: true } : n)),
+        },
+        { revalidate: false },
+      );
+      try {
+        await notificationsApi.markRead(sortKey);
+      } finally {
+        mutateNotifs();
+      }
+    },
+    markAllRead: async () => {
+      mutateNotifs(
+        (prev) => prev && {
+          ...prev,
+          items: prev.items.map((n) => ({ ...n, read: true })),
+        },
+        { revalidate: false },
+      );
+      try {
+        await notificationsApi.markAllRead();
+      } finally {
+        mutateNotifs();
+      }
+    },
   };
 }
 


### PR DESCRIPTION
New bell icon in header with coral count badge (refreshes every 30s via SWR `refreshInterval`). `/notifications` page shows newest-first list with avatars, contextual sentences ('@dom liked your recipe Pad Thai'), and bulk Mark-all-read.

Optimistic mark-read on click. Each notification jumps to the referenced recipe / cook / friends page.

Pairs with backend + infra notification PRs.