### PR TITLE
feat(search): /search page + Discover Load More cursor

### DIFF
--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -8,7 +8,7 @@ import Loader from '@/components/Loader';
 
 export default function DiscoverPage() {
   const { isAuthenticated, isLoading: authLoading } = useRequireAuth();
-  const { recipes, isLoading } = usePublicRecipes();
+  const { recipes, nextCursor, isLoading, loadMore } = usePublicRecipes();
   const { map: users } = useUsersById(recipes.map((r) => r.authorUserId));
   const dataReady = isAuthenticated && !isLoading;
 
@@ -31,6 +31,18 @@ export default function DiscoverPage() {
           {recipes.map((r) => (
             <RecipeCard key={r.recipeId} recipe={r} author={users.get(r.authorUserId)} />
           ))}
+        </div>
+      )}
+
+      {dataReady && nextCursor && (
+        <div className="text-center pt-2">
+          <button
+            type="button"
+            onClick={() => loadMore()}
+            className="bg-zinc-900 hover:bg-zinc-800 border border-zinc-800 hover:border-coral-500/50 text-zinc-100 px-5 py-2 rounded-lg text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-coral-400/40"
+          >
+            Load more
+          </button>
         </div>
       )}
     </main>

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,155 @@
+'use client';
+import { FormEvent, Suspense, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRequireAuth } from '@/lib/auth-context';
+import { searchApi, usersSearchApi } from '@/lib/api';
+import { PublicUserProfile } from '@/lib/users';
+import { useUsersById } from '@/lib/use-users-by-id';
+import { Recipe } from '@/types';
+import { RecipeCard } from '@/components/RecipeCard';
+import Loader from '@/components/Loader';
+
+export default function SearchPage() {
+  return (
+    <Suspense fallback={<Loader caption="loading…" />}>
+      <SearchInner />
+    </Suspense>
+  );
+}
+
+function SearchInner() {
+  const { isAuthenticated, isLoading: authLoading } = useRequireAuth();
+  const [draft, setDraft] = useState('');
+  const [q, setQ] = useState('');
+  const [recipes, setRecipes] = useState<Recipe[]>([]);
+  const [users, setUsers] = useState<PublicUserProfile[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Resolve recipe authors for card display.
+  const { map: authorMap } = useUsersById(recipes.map((r) => r.authorUserId));
+
+  useEffect(() => {
+    if (!isAuthenticated || !q.trim() || q.trim().length < 2) {
+      setRecipes([]);
+      setUsers([]);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    Promise.allSettled([searchApi.recipes(q), usersSearchApi.byHandlePrefix(q)])
+      .then(([rRes, uRes]) => {
+        if (cancelled) return;
+        setRecipes(rRes.status === 'fulfilled' ? rRes.value.items : []);
+        setUsers(uRes.status === 'fulfilled' ? uRes.value.users : []);
+        if (rRes.status === 'rejected' && uRes.status === 'rejected') {
+          setError('Search failed. Try again.');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [isAuthenticated, q]);
+
+  const onSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    setQ(draft.trim());
+  };
+
+  if (authLoading) return <Loader fullscreen />;
+
+  return (
+    <main className="max-w-6xl mx-auto px-4 py-6 space-y-6">
+      <div>
+        <h2 className="font-display text-2xl font-black uppercase tracking-wide">Search</h2>
+        <p className="text-sm text-zinc-400 mt-1">Recipes by name, people by handle.</p>
+      </div>
+
+      <form onSubmit={onSubmit} className="flex gap-2">
+        <input
+          type="search"
+          autoFocus
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder="pad thai, @dom, …"
+          className="flex-1 bg-zinc-950 border border-zinc-800 rounded-lg px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-coral-400/40 focus:border-coral-400"
+        />
+        <button
+          type="submit"
+          disabled={draft.trim().length < 2}
+          className="bg-gradient-to-r from-coral-500 to-coral-400 hover:from-coral-400 hover:to-coral-300 disabled:opacity-40 text-white px-4 py-2 rounded-lg text-sm font-bold uppercase tracking-wide transition focus:outline-none focus:ring-2 focus:ring-coral-400/50"
+        >
+          Search
+        </button>
+      </form>
+
+      {error && <p role="alert" className="text-coral-300 text-sm">{error}</p>}
+
+      {loading ? (
+        <Loader caption="searching…" />
+      ) : !q ? (
+        <p className="text-sm text-zinc-500 italic py-8">
+          Type at least 2 characters to search.
+        </p>
+      ) : (
+        <>
+          <section className="space-y-3">
+            <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-400">
+              People {users.length > 0 && <span className="text-zinc-600">· {users.length}</span>}
+            </h3>
+            {users.length === 0 ? (
+              <p className="text-zinc-500 italic text-sm">No matching handles.</p>
+            ) : (
+              <ul className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                {users.map((u) => (
+                  <li key={u.userId}>
+                    <Link
+                      href={u.preferredUsername ? `/u/view?handle=${encodeURIComponent(u.preferredUsername)}` : '#'}
+                      className="flex items-center gap-3 bg-zinc-900/60 border border-zinc-800 hover:border-coral-500/50 rounded-lg p-3 transition"
+                    >
+                      <div className="h-10 w-10 rounded-full overflow-hidden bg-zinc-800 grid place-items-center shrink-0">
+                        {u.avatarUrl ? (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img src={u.avatarUrl} alt="" className="h-full w-full object-cover" />
+                        ) : (
+                          <span className="h-full w-full grid place-items-center bg-gradient-to-br from-coral-500 to-flame-500 text-white text-sm font-black">
+                            {(u.displayName || u.preferredUsername || '?').charAt(0).toUpperCase()}
+                          </span>
+                        )}
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-sm font-semibold text-zinc-100 truncate">
+                          {u.displayName || `@${u.preferredUsername}`}
+                        </p>
+                        {u.preferredUsername && (
+                          <p className="text-[11px] text-zinc-500">@{u.preferredUsername}</p>
+                        )}
+                      </div>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          <section className="space-y-3">
+            <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-400">
+              Recipes {recipes.length > 0 && <span className="text-zinc-600">· {recipes.length}</span>}
+            </h3>
+            {recipes.length === 0 ? (
+              <p className="text-zinc-500 italic text-sm">No matching recipes.</p>
+            ) : (
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                {recipes.map((r) => (
+                  <RecipeCard key={r.recipeId} recipe={r} author={authorMap.get(r.authorUserId)} />
+                ))}
+              </div>
+            )}
+          </section>
+        </>
+      )}
+    </main>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -230,3 +230,36 @@ export const reportsApi = {
   add: (refType: ReportRefType, refId: string, reason?: string): Promise<{ status: 'received' }> =>
     apiPost('/reports/add', { refType, refId, reason: reason || '' }),
 };
+
+export const searchApi = {
+  recipes: (q: string, limit = 30): Promise<{ items: Recipe[] }> =>
+    apiPost<{ items: Recipe[] }>('/recipes/search', { q, limit }),
+};
+
+const USERS_API_BASE_URL =
+  process.env.NEXT_PUBLIC_USERS_API_URL || 'https://api.xomware.com';
+
+/** Cross-domain user search via xomware /users/search. Direct fetch
+ * because USERS_API_BASE differs from xomappetit's API_BASE. */
+export const usersSearchApi = {
+  byHandlePrefix: async (
+    q: string,
+    limit = 20,
+  ): Promise<{ users: import('./users').PublicUserProfile[] }> => {
+    const auth = await authHeaders();
+    const res = await fetch(`${USERS_API_BASE_URL}/users/search`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...auth },
+      body: JSON.stringify({ q, limit }),
+    });
+    if (res.status === 401) {
+      handleUnauthorized();
+      throw new AuthRequiredError();
+    }
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      throw new Error(`Users search ${res.status}: ${text}`);
+    }
+    return res.json();
+  },
+};

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import useSWR, { mutate } from 'swr';
 import {
   CreateRecipeInput,
@@ -185,18 +186,45 @@ export function useFriends() {
   };
 }
 
-/** Public recipes feed — anyone signed in can read this. */
+/**
+ * Public recipes feed with cursor pagination.
+ *
+ * SWR fetches the first page; subsequent pages live in local state and
+ * append on `loadMore()`. Refetch on focus is disabled to avoid
+ * obliterating the appended state.
+ */
 export function usePublicRecipes() {
   const { isAuthenticated } = useAuth();
   const { data, error, isLoading } = useSWR(
     isAuthenticated ? 'recipes:public' : null,
     () => recipesApi.listPublic({ limit: 50 }),
+    { revalidateOnFocus: false },
   );
+
+  const [extraPages, setExtraPages] = useState<{
+    items: Awaited<ReturnType<typeof recipesApi.listPublic>>['items'];
+    nextCursor: string | null;
+  }[]>([]);
+
+  const recipes = [
+    ...(data?.items ?? []),
+    ...extraPages.flatMap((p) => p.items),
+  ];
+  const nextCursor =
+    extraPages.length > 0
+      ? extraPages[extraPages.length - 1].nextCursor
+      : data?.nextCursor ?? null;
+
   return {
-    recipes: data?.items ?? [],
-    nextCursor: data?.nextCursor ?? null,
+    recipes,
+    nextCursor,
     isLoading: isAuthenticated ? isLoading : false,
     error,
+    loadMore: async () => {
+      if (!nextCursor) return;
+      const next = await recipesApi.listPublic({ limit: 50, cursor: nextCursor });
+      setExtraPages((prev) => [...prev, { items: next.items, nextCursor: next.nextCursor }]);
+    },
   };
 }
 


### PR DESCRIPTION
Top-level Search route hitting both `/recipes/search` and `/users/search` in parallel. Discover gets a Load More button driven by cursor pagination on `recipes/list-public`.

Pairs with **xomware-infrastructure#44** (users-search) + **xomappetit-backend feat/search-and-pagination** + **xomappetit-infrastructure feat/search-and-pagination**.