### PR TITLE
feat(mobile): hamburger drawer nav + responsive profile header

### DIFF
--- a/src/app/u/view/page.tsx
+++ b/src/app/u/view/page.tsx
@@ -69,33 +69,35 @@ function UserPageInner() {
 
   return (
     <main className="max-w-6xl mx-auto px-4 py-6 space-y-6">
-      <header className="flex items-center gap-4">
-        <div className="h-20 w-20 rounded-full overflow-hidden bg-zinc-800 border border-zinc-700 grid place-items-center shrink-0">
-          {profile.avatarUrl ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img src={profile.avatarUrl} alt="" className="h-full w-full object-cover" />
-          ) : (
-            <span className="h-full w-full grid place-items-center bg-gradient-to-br from-coral-500 to-flame-500 text-white text-2xl font-black uppercase">
-              {initial}
-            </span>
-          )}
-        </div>
-        <div className="min-w-0 flex-1">
-          <h1 className="font-display text-2xl font-black tracking-tight truncate">
-            {profile.displayName || `@${profile.preferredUsername}`}
-          </h1>
-          {profile.preferredUsername && (
-            <p className="text-sm text-zinc-400">@{profile.preferredUsername}</p>
-          )}
+      <header className="flex flex-col sm:flex-row sm:items-center gap-4">
+        <div className="flex items-center gap-4 min-w-0 flex-1">
+          <div className="h-16 w-16 sm:h-20 sm:w-20 rounded-full overflow-hidden bg-zinc-800 border border-zinc-700 grid place-items-center shrink-0">
+            {profile.avatarUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={profile.avatarUrl} alt="" className="h-full w-full object-cover" />
+            ) : (
+              <span className="h-full w-full grid place-items-center bg-gradient-to-br from-coral-500 to-flame-500 text-white text-2xl font-black uppercase">
+                {initial}
+              </span>
+            )}
+          </div>
+          <div className="min-w-0 flex-1">
+            <h1 className="font-display text-xl sm:text-2xl font-black tracking-tight truncate">
+              {profile.displayName || `@${profile.preferredUsername}`}
+            </h1>
+            {profile.preferredUsername && (
+              <p className="text-sm text-zinc-400 truncate">@{profile.preferredUsername}</p>
+            )}
+          </div>
         </div>
         {!isSelf && (
-          <>
+          <div className="flex items-center gap-2 sm:shrink-0">
             <FriendButton targetUserId={profile.userId} />
             <UserActionsMenu
               targetUserId={profile.userId}
               targetHandle={profile.preferredUsername}
             />
-          </>
+          </div>
         )}
       </header>
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,23 +8,57 @@ import { useFriends, useNotifications } from '@/lib/hooks';
 import Brand from './Brand';
 
 export default function Header() {
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
   return (
-    <header className="border-b border-zinc-800 bg-zinc-950/95 backdrop-blur sticky top-0 z-30">
-      <div className="max-w-6xl mx-auto px-4 h-16 flex items-center justify-between gap-4">
-        <Link
-          href="/"
-          aria-label="Xom Appétit home"
-          className="inline-flex items-center focus:outline-none focus:ring-2 focus:ring-coral-400/50 rounded"
-        >
-          <Brand height={44} />
-        </Link>
-        <div className="flex items-center gap-2">
-          <NavLinks />
-          <NotificationsBell />
-          <UserMenu />
+    <>
+      <header className="border-b border-zinc-800 bg-zinc-950/95 backdrop-blur sticky top-0 z-30">
+        <div className="max-w-6xl mx-auto px-4 h-16 flex items-center justify-between gap-3">
+          <Link
+            href="/"
+            aria-label="Xom Appétit home"
+            className="inline-flex items-center shrink-0 focus:outline-none focus:ring-2 focus:ring-coral-400/50 rounded"
+          >
+            <Brand height={44} className="hidden sm:block" />
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src="/icon.png"
+              alt="Xom Appétit"
+              className="sm:hidden h-9 w-9 rounded-md"
+              draggable={false}
+            />
+          </Link>
+
+          {/* Desktop cluster */}
+          <div className="hidden sm:flex items-center gap-2">
+            <NavLinks />
+            <NotificationsBell />
+            <UserMenu />
+          </div>
+
+          {/* Mobile cluster */}
+          <div className="sm:hidden flex items-center gap-1">
+            <NotificationsBell />
+            <button
+              type="button"
+              onClick={() => setDrawerOpen(true)}
+              aria-label="Open menu"
+              aria-expanded={drawerOpen}
+              className="h-10 w-10 grid place-items-center rounded-md text-zinc-300 hover:text-white hover:bg-zinc-800 transition focus:outline-none focus:ring-2 focus:ring-coral-400/50"
+            >
+              <svg viewBox="0 0 24 24" className="h-6 w-6" aria-hidden="true">
+                <path
+                  fill="currentColor"
+                  d="M3 6h18v2H3V6zm0 5h18v2H3v-2zm0 5h18v2H3v-2z"
+                />
+              </svg>
+            </button>
+          </div>
         </div>
-      </div>
-    </header>
+      </header>
+
+      <MobileDrawer open={drawerOpen} onClose={() => setDrawerOpen(false)} />
+    </>
   );
 }
 
@@ -32,29 +66,20 @@ function NavLinks() {
   const pathname = usePathname() || '/';
   const isFeed = pathname === '/' || pathname.startsWith('/recipes');
   const isDiscover = pathname.startsWith('/discover') || pathname.startsWith('/u/');
+  const isSearch = pathname.startsWith('/search');
   const isFriends = pathname.startsWith('/friends');
   const isCooks = pathname.startsWith('/cooks');
 
-  // Pulse a coral dot on the Friends tab whenever there's an unanswered
-  // incoming request. SWR caches this across pages so opening any route
-  // reveals the count without a flicker.
   const { incomingPending } = useFriends();
   const friendsBadge = incomingPending.length;
 
   return (
     <nav className="flex items-center gap-1 bg-zinc-900 rounded-lg p-0.5 border border-zinc-800">
-      <NavLink href="/" active={isFeed}>
-        Feed
-      </NavLink>
-      <NavLink href="/discover" active={isDiscover}>
-        Discover
-      </NavLink>
-      <NavLink href="/friends" active={isFriends} badge={friendsBadge}>
-        Friends
-      </NavLink>
-      <NavLink href="/cooks" active={isCooks}>
-        Cooks
-      </NavLink>
+      <NavLink href="/" active={isFeed}>Feed</NavLink>
+      <NavLink href="/discover" active={isDiscover}>Discover</NavLink>
+      <NavLink href="/search" active={isSearch}>Search</NavLink>
+      <NavLink href="/friends" active={isFriends} badge={friendsBadge}>Friends</NavLink>
+      <NavLink href="/cooks" active={isCooks}>Cooks</NavLink>
     </nav>
   );
 }
@@ -95,9 +120,8 @@ function NotificationsBell() {
     <Link
       href="/notifications"
       aria-label={`Notifications${unreadCount > 0 ? ` (${unreadCount} unread)` : ''}`}
-      className={`relative inline-flex items-center justify-center h-9 w-9 rounded-md transition focus:outline-none focus:ring-2 focus:ring-coral-400/50 ${cls}`}
+      className={`relative inline-flex items-center justify-center h-10 w-10 sm:h-9 sm:w-9 rounded-md transition focus:outline-none focus:ring-2 focus:ring-coral-400/50 ${cls}`}
     >
-      {/* Bell icon */}
       <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" aria-hidden="true">
         <path
           d="M12 22a2 2 0 0 0 2-2h-4a2 2 0 0 0 2 2zm6-6V11a6 6 0 0 0-5-5.91V4a1 1 0 1 0-2 0v1.09A6 6 0 0 0 6 11v5l-2 2v1h16v-1l-2-2z"
@@ -106,7 +130,7 @@ function NotificationsBell() {
       </svg>
       {unreadCount > 0 && (
         <span
-          className="absolute top-0 right-0 min-w-[1rem] h-4 px-1 rounded-full bg-coral-500 text-[10px] leading-4 font-bold text-white text-center"
+          className="absolute top-1 right-1 sm:top-0 sm:right-0 min-w-[1rem] h-4 px-1 rounded-full bg-coral-500 text-[10px] leading-4 font-bold text-white text-center"
           aria-hidden="true"
         >
           {unreadCount > 9 ? '9+' : unreadCount}
@@ -175,10 +199,8 @@ function UserMenu() {
             </span>
           )}
         </span>
-        <span className="max-w-[8rem] truncate hidden sm:inline">{label}</span>
-        <span className="text-zinc-500" aria-hidden="true">
-          ▾
-        </span>
+        <span className="max-w-[8rem] truncate hidden md:inline">{label}</span>
+        <span className="text-zinc-500" aria-hidden="true">▾</span>
       </button>
 
       {open && (
@@ -198,6 +220,14 @@ function UserMenu() {
           >
             Profile
           </Link>
+          <Link
+            role="menuitem"
+            href="/blocks"
+            className="block px-3 py-2 text-sm text-zinc-200 hover:bg-zinc-800 hover:text-coral-300 transition"
+            onClick={() => setOpen(false)}
+          >
+            Blocked users
+          </Link>
           <button
             role="menuitem"
             type="button"
@@ -214,6 +244,171 @@ function UserMenu() {
           </button>
         </div>
       )}
+    </div>
+  );
+}
+
+function MobileDrawer({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const { user, isAuthenticated, signOut } = useAuth();
+  const { profile } = useProfile();
+  const { incomingPending } = useFriends();
+  const { unreadCount } = useNotifications();
+  const pathname = usePathname() || '/';
+
+  // Close on route change so navigation feels native.
+  useEffect(() => {
+    if (open) onClose();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname]);
+
+  // Esc + body scroll lock while drawer is open.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', onKey);
+    const prev = document.documentElement.style.overflow;
+    document.documentElement.style.overflow = 'hidden';
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      document.documentElement.style.overflow = prev;
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const friendsBadge = incomingPending.length;
+  const handle = profile?.preferredUsername ?? user?.preferredUsername;
+  const label = profile?.displayName?.trim() || handle || 'You';
+  const avatarUrl = profile?.avatarUrl ?? null;
+  const initial = (label || 'U').charAt(0);
+
+  const items: Array<{ href: string; label: string; active: boolean; badge?: number }> = [
+    { href: '/', label: 'Feed', active: pathname === '/' || pathname.startsWith('/recipes') },
+    { href: '/discover', label: 'Discover', active: pathname.startsWith('/discover') || pathname.startsWith('/u/') },
+    { href: '/search', label: 'Search', active: pathname.startsWith('/search') },
+    { href: '/friends', label: 'Friends', active: pathname.startsWith('/friends'), badge: friendsBadge },
+    { href: '/cooks', label: 'Cooks', active: pathname.startsWith('/cooks') },
+    { href: '/notifications', label: 'Notifications', active: pathname.startsWith('/notifications'), badge: unreadCount },
+  ];
+
+  return (
+    <div className="fixed inset-0 z-50 sm:hidden" role="dialog" aria-modal="true" aria-label="Menu">
+      <button
+        type="button"
+        aria-label="Close menu"
+        onClick={onClose}
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+      />
+      <aside className="absolute right-0 top-0 h-full w-72 max-w-[85%] bg-zinc-950 border-l border-zinc-800 shadow-2xl flex flex-col">
+        <div className="flex items-center justify-between gap-3 p-4 border-b border-zinc-800">
+          {isAuthenticated && user ? (
+            <Link
+              href="/profile"
+              onClick={onClose}
+              className="flex items-center gap-3 min-w-0 flex-1 focus:outline-none focus:ring-2 focus:ring-coral-400/40 rounded-md -m-1 p-1"
+            >
+              <span className="h-10 w-10 rounded-full overflow-hidden bg-zinc-800 grid place-items-center shrink-0">
+                {avatarUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={avatarUrl} alt="" className="h-full w-full object-cover" />
+                ) : (
+                  <span className="h-full w-full grid place-items-center bg-gradient-to-br from-coral-500 to-flame-500 text-white text-sm font-black uppercase">
+                    {initial}
+                  </span>
+                )}
+              </span>
+              <div className="min-w-0">
+                <p className="text-sm font-semibold text-zinc-100 truncate">{label}</p>
+                {handle && <p className="text-xs text-zinc-500 truncate">@{handle}</p>}
+              </div>
+            </Link>
+          ) : (
+            <div className="flex items-center gap-3 min-w-0 flex-1">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src="/icon.png" alt="" className="h-9 w-9 rounded-md" />
+              <p className="text-sm font-semibold text-zinc-100">Xom Appétit</p>
+            </div>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close menu"
+            className="h-9 w-9 grid place-items-center rounded-md text-zinc-400 hover:text-white hover:bg-zinc-800 transition focus:outline-none focus:ring-2 focus:ring-coral-400/40"
+          >
+            <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden="true">
+              <path
+                fill="currentColor"
+                d="M6.4 4.99 12 10.6l5.6-5.61 1.41 1.41L13.41 12l5.6 5.6-1.41 1.41L12 13.41l-5.6 5.6-1.41-1.41L10.59 12l-5.6-5.6L6.4 4.99z"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <nav className="flex-1 overflow-y-auto py-2">
+          {items.map((it) => (
+            <Link
+              key={it.href}
+              href={it.href}
+              onClick={onClose}
+              aria-current={it.active ? 'page' : undefined}
+              className={`flex items-center justify-between px-4 py-3 text-base font-medium transition ${
+                it.active
+                  ? 'bg-zinc-900 text-coral-300 border-l-2 border-coral-400'
+                  : 'text-zinc-200 hover:bg-zinc-900 hover:text-white border-l-2 border-transparent'
+              }`}
+            >
+              <span>{it.label}</span>
+              {it.badge && it.badge > 0 ? (
+                <span className="min-w-[1.25rem] h-5 px-1.5 rounded-full bg-coral-500 text-[11px] leading-5 font-bold text-white text-center">
+                  {it.badge > 9 ? '9+' : it.badge}
+                </span>
+              ) : null}
+            </Link>
+          ))}
+        </nav>
+
+        <div className="border-t border-zinc-800 py-2">
+          {isAuthenticated && user ? (
+            <>
+              <Link
+                href="/profile"
+                onClick={onClose}
+                className="block px-4 py-3 text-sm text-zinc-200 hover:bg-zinc-900 hover:text-coral-300 transition"
+              >
+                Profile
+              </Link>
+              <Link
+                href="/blocks"
+                onClick={onClose}
+                className="block px-4 py-3 text-sm text-zinc-200 hover:bg-zinc-900 hover:text-coral-300 transition"
+              >
+                Blocked users
+              </Link>
+              <button
+                type="button"
+                onClick={async () => {
+                  onClose();
+                  await signOut();
+                  if (typeof window !== 'undefined') {
+                    window.location.assign('/auth/sign-in');
+                  }
+                }}
+                className="w-full text-left px-4 py-3 text-sm text-zinc-200 hover:bg-zinc-900 hover:text-coral-300 transition"
+              >
+                Sign out
+              </button>
+            </>
+          ) : (
+            <Link
+              href="/auth/sign-in"
+              onClick={onClose}
+              className="block mx-4 my-2 text-center bg-gradient-to-r from-coral-500 to-coral-400 hover:from-coral-400 hover:to-coral-300 text-white font-bold uppercase tracking-wider px-4 py-2.5 rounded-lg transition shadow-lg shadow-coral-500/20"
+            >
+              Sign in
+            </Link>
+          )}
+        </div>
+      </aside>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replaces the cluttered top nav (5 tabs + bell + user menu) on mobile with `icon + bell + hamburger` and a slide-in side drawer
- Banner wordmark stays on desktop; square `/icon.png` shows on mobile so the brand is visible at every breakpoint
- `/u/view` header stacks identity row on top of the action buttons on mobile so name + avatar + Add friend + ⋯ menu no longer collide

## Drawer details
- Right-anchored panel, 18rem / 85vw cap
- Items: Feed, Discover, Search, Friends (+ pending badge), Cooks, Notifications (+ unread badge)
- Bottom: Profile, Blocked users, Sign out (or Sign in if logged out)
- Closes on route change, Esc, backdrop tap; locks `<html>` scroll while open
- Tap targets bumped to 40px on mobile (bell + hamburger)

## Test plan
- [ ] iPhone-sized viewport: header shows icon + bell + hamburger only
- [ ] Tap hamburger → drawer slides in from right with profile card and full nav
- [ ] Tap a nav item → drawer closes and route changes
- [ ] Esc + backdrop tap close the drawer
- [ ] Desktop ≥ 640px: header is unchanged (banner + tabs + bell + user menu)
- [ ] `/u/view` on mobile: avatar/name on row 1, Add friend / ⋯ on row 2; on desktop everything stays inline