### PR TITLE
fix(mobile): no iOS focus zoom + no horizontal scroll + fix stale copy

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -66,3 +66,22 @@
 .animate-brand-pulse {
   animation: brand-pulse 1.6s ease-in-out infinite;
 }
+
+/* Prevent iOS Safari from auto-zooming on input focus when font-size < 16px.
+ * Tailwind's `text-sm` = 14px, which triggers the zoom; bump form controls up
+ * to 16px on small viewports while leaving the visual sizing untouched on
+ * larger screens. */
+@media (max-width: 640px) {
+  input,
+  textarea,
+  select {
+    font-size: 16px;
+  }
+}
+
+/* Containment guard against rogue overflow (long words, oversized embeds).
+ * Keeps the page from horizontally scrolling on phones. */
+html,
+body {
+  overflow-x: hidden;
+}

--- a/src/components/RecipeForm.tsx
+++ b/src/components/RecipeForm.tsx
@@ -7,7 +7,7 @@ import InstructionsEditor from './InstructionsEditor';
 const DIFFICULTIES: Difficulty[] = ['Easy', 'Medium', 'Hard'];
 const PRIVACIES: { value: Privacy; label: string; hint: string }[] = [
   { value: 'private', label: 'Private', hint: 'Only you can see it.' },
-  { value: 'friends', label: 'Friends', hint: 'Friends only (friends feature coming).' },
+  { value: 'friends', label: 'Friends', hint: 'Visible to your accepted friends.' },
   { value: 'public', label: 'Public', hint: 'Anyone can find and view it.' },
 ];
 


### PR DESCRIPTION
## Summary
- iOS Safari auto-zooms when a focused input has font-size < 16px. Tailwind's \`text-sm\` is 14px, which triggers the zoom across every form on the app. Added a \`@media (max-width: 640px)\` rule to bump form controls to 16px on phones while leaving desktop styling alone
- Added \`overflow-x: hidden\` on html/body as a containment guard against any single rogue long string or embed forcing the page to scroll sideways
- RecipeForm 'Friends' privacy hint still said 'friends feature coming' — friends shipped weeks ago. Updated copy

## Test plan
- [ ] iPhone Safari: focus the search input or a recipe-name field — page does not zoom in
- [ ] Long URLs / unbroken strings in recipe descriptions don't push the page wider than the viewport
- [ ] Privacy radios on /recipes/new show the correct hints