### PR TITLE
fix(mobile): add viewport meta so pages render at device width

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import Script from 'next/script';
 import './globals.css';
 import { AuthProvider } from '@/lib/auth-context';
@@ -7,6 +7,19 @@ import AppShell from '@/components/AppShell';
 export const metadata: Metadata = {
   title: 'Xom Appétit',
   description: 'Cook it. Log it. Rate it. Get roasted.',
+};
+
+// Without this, mobile browsers fall back to a ~980px desktop viewport, so
+// content overflows and users have to pinch-zoom to read. Locking zoom
+// matches the user's "feels like a real app" goal — pages render at the
+// device width and stay there.
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+  viewportFit: 'cover',
+  themeColor: '#0a0a0a',
 };
 
 const GA4_ID = process.env.NEXT_PUBLIC_GA4_MEASUREMENT_ID;


### PR DESCRIPTION
## Summary
Root cause of the 'I can scroll sides and zoom in and out a lot' bug: the app had no \`<meta name=viewport>\`, so mobile browsers used the default ~980px desktop viewport. Pages rendered at desktop width and squished to fit, which is why pinch-zoom was being used to read.

Adds a Next.js \`viewport\` export in the root layout:
- \`width=device-width, initial-scale=1\` → page actually renders at phone width
- \`maximum-scale=1, user-scalable=no\` → no rogue pinch-zoom; native-app feel
- \`viewport-fit=cover\` → respects iPhone notch/safe-areas
- \`theme-color: #0a0a0a\` → matches the dark UI in the iOS status bar

## Test plan
- [ ] iPhone Safari: page renders edge-to-edge at the phone's width, no horizontal scroll
- [ ] Pinch-zoom is disabled
- [ ] iPhone with notch: status bar matches the dark zinc background instead of being white