### PR TITLE
feat(taxonomy): structured ingredients, units, tags, multi-axis ratings, per-step ingredients

### DIFF
--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -1,31 +1,194 @@
 'use client';
+import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useRequireAuth } from '@/lib/auth-context';
-import { usePublicRecipes } from '@/lib/hooks';
 import { useUsersById } from '@/lib/use-users-by-id';
+import { useAuth } from '@/lib/auth-context';
+import { recipesApi } from '@/lib/api';
+import {
+  Recipe,
+  Tag,
+  TAG_GROUPS,
+  TAG_LABELS,
+  ProteinType,
+  PROTEIN_TYPES,
+  PROTEIN_LABELS,
+} from '@/types';
 import { RecipeCard } from '@/components/RecipeCard';
 import Loader from '@/components/Loader';
 
 export default function DiscoverPage() {
   const { isAuthenticated, isLoading: authLoading } = useRequireAuth();
-  const { recipes, nextCursor, isLoading, loadMore } = usePublicRecipes();
-  const { map: users } = useUsersById(recipes.map((r) => r.authorUserId));
-  const dataReady = isAuthenticated && !isLoading;
+  const auth = useAuth();
+  const [filterTags, setFilterTags] = useState<Tag[]>([]);
+  const [filterProteins, setFilterProteins] = useState<ProteinType[]>([]);
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const [recipes, setRecipes] = useState<Recipe[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  // Refetch from page 1 whenever filters change. Server applies them, so
+  // pagination cursor becomes invalid on a filter change.
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    let cancelled = false;
+    setLoading(true);
+    recipesApi
+      .listPublic({
+        limit: 50,
+        tags: filterTags.length > 0 ? filterTags : undefined,
+        proteinTypes: filterProteins.length > 0 ? filterProteins : undefined,
+      })
+      .then((res) => {
+        if (cancelled) return;
+        setRecipes(res.items);
+        setNextCursor(res.nextCursor);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated, filterTags, filterProteins, auth.user?.sub]);
+
+  const loadMore = async () => {
+    if (!nextCursor) return;
+    setLoading(true);
+    try {
+      const res = await recipesApi.listPublic({
+        limit: 50,
+        cursor: nextCursor,
+        tags: filterTags.length > 0 ? filterTags : undefined,
+        proteinTypes: filterProteins.length > 0 ? filterProteins : undefined,
+      });
+      setRecipes((prev) => [...prev, ...res.items]);
+      setNextCursor(res.nextCursor);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const authorIds = useMemo(() => recipes.map((r) => r.authorUserId), [recipes]);
+  const { map: users } = useUsersById(authorIds);
+  const dataReady = isAuthenticated;
+  const activeFilterCount = filterTags.length + filterProteins.length;
+
+  const toggleTag = (t: Tag) =>
+    setFilterTags((prev) => (prev.includes(t) ? prev.filter((x) => x !== t) : [...prev, t]));
+  const toggleProtein = (p: ProteinType) =>
+    setFilterProteins((prev) =>
+      prev.includes(p) ? prev.filter((x) => x !== p) : [...prev, p],
+    );
+  const clearFilters = () => {
+    setFilterTags([]);
+    setFilterProteins([]);
+  };
 
   return (
     <main className="max-w-6xl mx-auto px-4 py-6 space-y-6">
-      <div>
-        <h2 className="font-display text-2xl font-black uppercase tracking-wide">Discover</h2>
-        <p className="text-sm text-zinc-400 mt-1">
-          <span className="text-coral-400 font-semibold">{recipes.length}</span>{' '}
-          public {recipes.length === 1 ? 'recipe' : 'recipes'} from the kitchen
-        </p>
+      <div className="flex items-end justify-between gap-3 flex-wrap">
+        <div>
+          <h2 className="font-display text-2xl font-black uppercase tracking-wide">Discover</h2>
+          <p className="text-sm text-zinc-400 mt-1">
+            <span className="text-coral-400 font-semibold">{recipes.length}</span>{' '}
+            public {recipes.length === 1 ? 'recipe' : 'recipes'} from the kitchen
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setFiltersOpen((v) => !v)}
+          aria-expanded={filtersOpen}
+          className={`flex items-center gap-2 text-sm font-semibold px-3 py-2 rounded-lg border transition focus:outline-none focus:ring-2 focus:ring-coral-400/40 ${
+            activeFilterCount > 0
+              ? 'bg-coral-500/15 border-coral-500/40 text-coral-200'
+              : 'bg-zinc-900 border-zinc-800 text-zinc-300 hover:border-zinc-700'
+          }`}
+        >
+          <span>Filters</span>
+          {activeFilterCount > 0 && (
+            <span className="bg-coral-500 text-white text-[10px] font-bold leading-4 min-w-[1rem] h-4 px-1 rounded-full">
+              {activeFilterCount}
+            </span>
+          )}
+        </button>
       </div>
 
-      {!dataReady || authLoading ? (
+      {filtersOpen && (
+        <section className="bg-zinc-900/60 border border-zinc-800 rounded-xl p-4 space-y-4">
+          <div className="flex items-center justify-between">
+            <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-400">
+              Filters
+            </h3>
+            {activeFilterCount > 0 && (
+              <button
+                type="button"
+                onClick={clearFilters}
+                className="text-xs text-zinc-400 hover:text-coral-300 transition"
+              >
+                Clear all
+              </button>
+            )}
+          </div>
+
+          <div>
+            <div className="text-[10px] uppercase tracking-wider text-zinc-500 mb-1.5">
+              Protein
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {PROTEIN_TYPES.map((p) => {
+                const on = filterProteins.includes(p);
+                return (
+                  <button
+                    key={p}
+                    type="button"
+                    onClick={() => toggleProtein(p)}
+                    className={`text-xs px-2.5 py-1 rounded-full border transition ${
+                      on
+                        ? 'bg-coral-500/20 border-coral-500/50 text-coral-200'
+                        : 'bg-zinc-900 border-zinc-800 text-zinc-400 hover:border-zinc-700 hover:text-zinc-200'
+                    }`}
+                  >
+                    {PROTEIN_LABELS[p]}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {TAG_GROUPS.map((group) => (
+            <div key={group.label}>
+              <div className="text-[10px] uppercase tracking-wider text-zinc-500 mb-1.5">
+                {group.label}
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {group.tags.map((t) => {
+                  const on = filterTags.includes(t);
+                  return (
+                    <button
+                      key={t}
+                      type="button"
+                      onClick={() => toggleTag(t)}
+                      className={`text-xs px-2.5 py-1 rounded-full border transition ${
+                        on
+                          ? 'bg-coral-500/20 border-coral-500/50 text-coral-200'
+                          : 'bg-zinc-900 border-zinc-800 text-zinc-400 hover:border-zinc-700 hover:text-zinc-200'
+                      }`}
+                    >
+                      {TAG_LABELS[t]}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </section>
+      )}
+
+      {!dataReady || authLoading || (loading && recipes.length === 0) ? (
         <Loader caption="finding recipes…" />
       ) : recipes.length === 0 ? (
-        <EmptyDiscover />
+        <EmptyDiscover hasFilters={activeFilterCount > 0} clear={clearFilters} />
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {recipes.map((r) => (
@@ -39,9 +202,10 @@ export default function DiscoverPage() {
           <button
             type="button"
             onClick={() => loadMore()}
-            className="bg-zinc-900 hover:bg-zinc-800 border border-zinc-800 hover:border-coral-500/50 text-zinc-100 px-5 py-2 rounded-lg text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-coral-400/40"
+            disabled={loading}
+            className="bg-zinc-900 hover:bg-zinc-800 border border-zinc-800 hover:border-coral-500/50 text-zinc-100 px-5 py-2 rounded-lg text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-coral-400/40 disabled:opacity-50"
           >
-            Load more
+            {loading ? 'Loading…' : 'Load more'}
           </button>
         </div>
       )}
@@ -49,22 +213,40 @@ export default function DiscoverPage() {
   );
 }
 
-function EmptyDiscover() {
+function EmptyDiscover({
+  hasFilters,
+  clear,
+}: {
+  hasFilters: boolean;
+  clear: () => void;
+}) {
   return (
     <div className="text-center py-16 border border-dashed border-zinc-800 rounded-xl">
       <div className="text-5xl mb-3">🍽️</div>
       <h3 className="font-display text-2xl font-black uppercase tracking-wide">
-        Nothing public yet
+        {hasFilters ? 'No matches' : 'Nothing public yet'}
       </h3>
       <p className="text-zinc-400 text-sm mt-2 max-w-sm mx-auto">
-        When chefs publish recipes, they show up here. Be the first.
+        {hasFilters
+          ? 'No public recipes match every filter you picked.'
+          : 'When chefs publish recipes, they show up here. Be the first.'}
       </p>
-      <Link
-        href="/recipes/new"
-        className="mt-5 inline-block bg-gradient-to-r from-coral-500 to-coral-400 hover:from-coral-400 hover:to-coral-300 text-white font-bold uppercase tracking-wider px-6 py-2.5 rounded-lg transition shadow-lg shadow-coral-500/20 focus:outline-none focus:ring-2 focus:ring-coral-400/50"
-      >
-        Add a recipe
-      </Link>
+      {hasFilters ? (
+        <button
+          type="button"
+          onClick={clear}
+          className="mt-5 inline-block bg-zinc-900 hover:bg-zinc-800 border border-zinc-800 hover:border-coral-500/50 text-zinc-100 font-bold uppercase tracking-wider px-6 py-2.5 rounded-lg transition"
+        >
+          Clear filters
+        </button>
+      ) : (
+        <Link
+          href="/recipes/new"
+          className="mt-5 inline-block bg-gradient-to-r from-coral-500 to-coral-400 hover:from-coral-400 hover:to-coral-300 text-white font-bold uppercase tracking-wider px-6 py-2.5 rounded-lg transition shadow-lg shadow-coral-500/20 focus:outline-none focus:ring-2 focus:ring-coral-400/50"
+        >
+          Add a recipe
+        </Link>
+      )}
     </div>
   );
 }

--- a/src/app/recipes/view/page.tsx
+++ b/src/app/recipes/view/page.tsx
@@ -9,7 +9,16 @@ import { RecipeComments } from '@/components/RecipeComments';
 import { RatingStars } from '@/components/RatingStars';
 import LikeButton from '@/components/LikeButton';
 import { PrivacyBadge } from '@/components/PrivacyBadge';
-import { Ingredient, ingredientLabel } from '@/types';
+import {
+  Ingredient,
+  Instruction,
+  TAG_LABELS,
+  PROTEIN_LABELS,
+  ingredientLabel,
+  ingredientName,
+  instructionText,
+  normalizeInstruction,
+} from '@/types';
 import { recipesApi } from '@/lib/api';
 import Loader from '@/components/Loader';
 
@@ -30,6 +39,7 @@ function RecipeViewInner() {
   const { recipe, isLoading, error, refresh, edit, remove } = useRecipe(recipeId);
   const [editing, setEditing] = useState(false);
   const [myRating, setMyRating] = useState<number>(0);
+  const [mySpiciness, setMySpiciness] = useState<number>(0);
   const [ratingSubmitting, setRatingSubmitting] = useState(false);
 
   if (authLoading || !isAuthenticated) {
@@ -58,11 +68,15 @@ function RecipeViewInner() {
 
   const isAuthor = user?.sub === recipe.authorUserId;
 
-  const handleRate = async (n: number) => {
-    setMyRating(n);
+  const handleRate = async (axis: 'overall' | 'spiciness', n: number) => {
+    if (axis === 'overall') setMyRating(n);
+    else setMySpiciness(n);
     setRatingSubmitting(true);
     try {
-      await recipesApi.rate(recipe.recipeId, n);
+      await recipesApi.rate(
+        recipe.recipeId,
+        axis === 'overall' ? { rating: n } : { spiciness: n },
+      );
       refresh();
     } finally {
       setRatingSubmitting(false);
@@ -141,23 +155,49 @@ function RecipeViewInner() {
             <PrivacyBadge privacy={recipe.privacy} showFriendsHint />
           </div>
 
-          <div className="flex flex-wrap items-center gap-3 text-xs text-zinc-400">
-            <span className="font-semibold text-zinc-200">{recipe.difficulty}</span>
+          <div className="flex flex-wrap items-center gap-2 text-xs text-zinc-400">
+            <DifficultyDots value={typeof recipe.difficulty === 'number' ? recipe.difficulty : 3} />
             {recipe.timeMinutes > 0 && (
               <>
                 <span className="text-zinc-700">·</span>
                 <span>{recipe.timeMinutes} min</span>
               </>
             )}
-            {recipe.proteinSource && (
+            {recipe.servings > 0 && (
               <>
                 <span className="text-zinc-700">·</span>
-                <span className="bg-coral-500/15 text-coral-300 px-2 py-0.5 rounded-full">
-                  {recipe.proteinSource}
+                <span>
+                  {recipe.servings} {recipe.servings === 1 ? 'serving' : 'servings'}
                 </span>
               </>
             )}
+            {(recipe.proteinTypes ?? []).map((p) => (
+              <span
+                key={p}
+                className="bg-coral-500/15 text-coral-300 px-2 py-0.5 rounded-full"
+              >
+                {PROTEIN_LABELS[p] ?? p}
+              </span>
+            ))}
+            {recipe.proteinSource && (recipe.proteinTypes ?? []).length === 0 && (
+              <span className="bg-coral-500/15 text-coral-300 px-2 py-0.5 rounded-full">
+                {recipe.proteinSource}
+              </span>
+            )}
           </div>
+
+          {(recipe.tags ?? []).length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {recipe.tags.map((t) => (
+                <span
+                  key={t}
+                  className="bg-zinc-800/80 text-zinc-300 text-[11px] px-2 py-0.5 rounded-full"
+                >
+                  {TAG_LABELS[t] ?? t}
+                </span>
+              ))}
+            </div>
+          )}
 
           <div className="flex items-center gap-3 pt-2">
             <LikeButton
@@ -168,7 +208,7 @@ function RecipeViewInner() {
             <span className="text-xs text-zinc-500">
               {recipe.cookCount} {recipe.cookCount === 1 ? 'cook' : 'cooks'}
             </span>
-            {recipe.ratingCount > 0 && (
+            {recipe.ratingCount > 0 && recipe.avgRating != null && (
               <span className="text-xs text-zinc-500">
                 ★ {recipe.avgRating.toFixed(1)} ({recipe.ratingCount})
               </span>
@@ -179,7 +219,11 @@ function RecipeViewInner() {
             <Stat label="Cooks" value={String(recipe.cookCount)} />
             <Stat
               label="Avg rating"
-              value={recipe.ratingCount > 0 ? recipe.avgRating.toFixed(1) : '–'}
+              value={
+                recipe.ratingCount > 0 && recipe.avgRating != null
+                  ? recipe.avgRating.toFixed(1)
+                  : '–'
+              }
               hint={recipe.ratingCount > 0 ? `${recipe.ratingCount} ratings` : 'no ratings yet'}
             />
             <Stat
@@ -189,42 +233,69 @@ function RecipeViewInner() {
           </div>
 
           {recipe.macros && (
-            <div className="grid grid-cols-4 gap-2 bg-zinc-950/50 border border-zinc-800 rounded-lg p-3 mt-2">
-              {[
-                ['Cal', recipe.macros.calories],
-                ['Protein', `${recipe.macros.protein}g`],
-                ['Carbs', `${recipe.macros.carbs}g`],
-                ['Fat', `${recipe.macros.fat}g`],
-              ].map(([label, val]) => (
-                <div key={label as string} className="text-center">
-                  <div className="text-[10px] uppercase tracking-wider text-zinc-500">
-                    {label}
+            <div className="bg-zinc-950/50 border border-zinc-800 rounded-lg p-3 mt-2">
+              <div className="text-[10px] uppercase tracking-wider text-zinc-500 mb-2">
+                Macros · {recipe.macrosScope === 'per-serving' ? 'per serving' : 'per recipe'}
+              </div>
+              <div className="grid grid-cols-4 gap-2">
+                {[
+                  ['Cal', recipe.macros.calories],
+                  ['Protein', `${recipe.macros.protein}g`],
+                  ['Carbs', `${recipe.macros.carbs}g`],
+                  ['Fat', `${recipe.macros.fat}g`],
+                ].map(([label, val]) => (
+                  <div key={label as string} className="text-center">
+                    <div className="text-[10px] uppercase tracking-wider text-zinc-500">
+                      {label}
+                    </div>
+                    <div className="font-bold text-base mt-0.5">{val}</div>
                   </div>
-                  <div className="font-bold text-base mt-0.5">{val}</div>
-                </div>
-              ))}
+                ))}
+              </div>
             </div>
           )}
 
-          <div className="pt-2 border-t border-zinc-800">
+          <div className="pt-2 border-t border-zinc-800 space-y-3">
             <div className="flex items-center justify-between gap-3">
               <div>
                 <div className="text-xs uppercase tracking-wider text-zinc-400 font-semibold">
-                  Your rating
+                  Overall
                 </div>
-                <p className="text-[11px] text-zinc-500 mt-0.5">
-                  Tap a star to rate this recipe.
-                </p>
+                {recipe.ratingCount > 0 && recipe.avgRating != null && (
+                  <p className="text-[11px] text-zinc-500 mt-0.5">
+                    avg {recipe.avgRating.toFixed(1)} · {recipe.ratingCount} {recipe.ratingCount === 1 ? 'rating' : 'ratings'}
+                  </p>
+                )}
               </div>
               <RatingStars
                 value={myRating}
-                onChange={(n) => void handleRate(n)}
+                onChange={(n) => void handleRate('overall', n)}
                 size="md"
                 label="Rate this recipe"
               />
             </div>
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <div className="text-xs uppercase tracking-wider text-zinc-400 font-semibold">
+                  Spiciness
+                </div>
+                {recipe.spicinessCount > 0 && recipe.spicinessAvg != null ? (
+                  <p className="text-[11px] text-zinc-500 mt-0.5">
+                    avg {recipe.spicinessAvg.toFixed(1)} · {recipe.spicinessCount} {recipe.spicinessCount === 1 ? 'rating' : 'ratings'}
+                  </p>
+                ) : (
+                  <p className="text-[11px] text-zinc-500 mt-0.5">no heat ratings yet</p>
+                )}
+              </div>
+              <RatingStars
+                value={mySpiciness}
+                onChange={(n) => void handleRate('spiciness', n)}
+                size="md"
+                label="Rate spiciness"
+              />
+            </div>
             {ratingSubmitting && (
-              <div className="text-[11px] text-zinc-500 italic mt-1">Saving…</div>
+              <div className="text-[11px] text-zinc-500 italic">Saving…</div>
             )}
           </div>
         </section>
@@ -255,14 +326,35 @@ function RecipeViewInner() {
             <div className="text-sm text-zinc-500 italic">No instructions yet.</div>
           ) : (
             <ol className="space-y-3">
-              {instructions.map((step, i) => (
-                <li key={i} className="flex items-start gap-3 text-sm">
-                  <span className="w-6 h-6 rounded-full bg-coral-500/20 text-coral-400 text-xs grid place-items-center font-bold flex-shrink-0 mt-0.5">
-                    {i + 1}
-                  </span>
-                  <span className="text-zinc-200 leading-relaxed">{step}</span>
-                </li>
-              ))}
+              {instructions.map((rawStep, i) => {
+                const step: Instruction = normalizeInstruction(rawStep);
+                const stepIngs = step.ingredientIndexes
+                  .map((idx) => ingredients[idx])
+                  .filter((x): x is Ingredient | string => Boolean(x));
+                return (
+                  <li key={i} className="flex items-start gap-3 text-sm">
+                    <span className="w-6 h-6 rounded-full bg-coral-500/20 text-coral-400 text-xs grid place-items-center font-bold flex-shrink-0 mt-0.5">
+                      {i + 1}
+                    </span>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-zinc-200 leading-relaxed">{step.text || instructionText(rawStep)}</p>
+                      {stepIngs.length > 0 && (
+                        <div className="mt-1.5 flex flex-wrap gap-1">
+                          {stepIngs.map((ing, idx) => (
+                            <span
+                              key={idx}
+                              className="text-[10px] bg-zinc-800/60 border border-zinc-800 text-zinc-400 px-1.5 py-0.5 rounded-full"
+                              title={ingredientLabel(ing)}
+                            >
+                              {ingredientName(ing)}
+                            </span>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </li>
+                );
+              })}
             </ol>
           )}
         </section>
@@ -291,6 +383,24 @@ function RecipeViewInner() {
         )}
       </main>
     </div>
+  );
+}
+
+function DifficultyDots({ value }: { value: number }) {
+  const v = Math.max(1, Math.min(5, Math.round(value)));
+  return (
+    <span
+      className="inline-flex items-center gap-0.5"
+      aria-label={`Difficulty ${v} of 5`}
+      title={`Difficulty ${v}/5`}
+    >
+      {[1, 2, 3, 4, 5].map((n) => (
+        <span
+          key={n}
+          className={`h-1.5 w-1.5 rounded-full ${n <= v ? 'bg-coral-400' : 'bg-zinc-700'}`}
+        />
+      ))}
+    </span>
   );
 }
 

--- a/src/components/IngredientsEditor.tsx
+++ b/src/components/IngredientsEditor.tsx
@@ -1,5 +1,14 @@
 'use client';
-import { Ingredient } from '@/types';
+import { useId, useMemo } from 'react';
+import {
+  Ingredient,
+  Unit,
+  UNITS,
+  UNIT_LABELS,
+  UNIT_DEFAULT_AMOUNTS,
+  UNITLESS_UNITS,
+} from '@/types';
+import { ingredientSuggestions } from '@/lib/common-ingredients';
 
 interface Props {
   ingredients: Ingredient[];
@@ -10,62 +19,107 @@ const inputCls =
   'bg-zinc-900 border border-zinc-700 rounded-md px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-coral-400 focus:border-transparent';
 
 export default function IngredientsEditor({ ingredients, onChange }: Props) {
+  const datalistId = useId();
+
+  // Suggestion list is per-render (cheap; reads from localStorage). Memoize
+  // so the <datalist> isn't re-rendered on every keystroke.
+  const suggestions = useMemo(() => ingredientSuggestions(), []);
+
   const update = (i: number, patch: Partial<Ingredient>) => {
     const next = ingredients.slice();
     next[i] = { ...next[i], ...patch };
     onChange(next);
   };
-  const add = () => onChange([...ingredients, { name: '', quantity: null, unit: null }]);
+
+  const handleUnitChange = (i: number, value: string) => {
+    const next = ingredients.slice();
+    const unit = value === '' ? null : (value as Unit);
+    const current = next[i];
+    let amount = current.amount;
+    // Unitless unit (to-taste/pinch/dash): drop the amount.
+    if (unit && UNITLESS_UNITS.has(unit)) amount = null;
+    // Switching from unset to a unit with a sensible default: prefill.
+    else if (unit && current.amount == null && UNIT_DEFAULT_AMOUNTS[unit] != null) {
+      amount = UNIT_DEFAULT_AMOUNTS[unit] ?? null;
+    }
+    next[i] = { ...current, unit, amount };
+    onChange(next);
+  };
+
+  const add = () => onChange([...ingredients, { name: '', amount: null, unit: null }]);
   const remove = (i: number) => onChange(ingredients.filter((_, idx) => idx !== i));
 
   return (
     <div className="space-y-2">
+      <datalist id={datalistId}>
+        {suggestions.map((s) => (
+          <option key={s} value={s} />
+        ))}
+      </datalist>
+
       {ingredients.length === 0 && (
         <div className="text-xs text-zinc-500 italic">
           No ingredients yet. Add your first one ↓
         </div>
       )}
-      {ingredients.map((ing, i) => (
-        <div key={i} className="grid grid-cols-[80px_80px_1fr_auto] gap-2 items-center">
-          <input
-            type="number"
-            min={0}
-            step="0.25"
-            placeholder="qty"
-            className={inputCls}
-            value={ing.quantity ?? ''}
-            onChange={(e) =>
-              update(i, {
-                quantity: e.target.value === '' ? null : Number(e.target.value),
-              })
-            }
-          />
-          <input
-            type="text"
-            placeholder="unit"
-            className={inputCls}
-            value={ing.unit ?? ''}
-            onChange={(e) =>
-              update(i, { unit: e.target.value || null })
-            }
-          />
-          <input
-            type="text"
-            placeholder="name (e.g. chicken breast)"
-            className={inputCls}
-            value={ing.name}
-            onChange={(e) => update(i, { name: e.target.value })}
-          />
-          <button
-            type="button"
-            onClick={() => remove(i)}
-            className="text-zinc-500 hover:text-coral-400 text-lg leading-none w-7 h-7 grid place-items-center"
-            aria-label="Remove ingredient"
+
+      {ingredients.map((ing, i) => {
+        const unitless = ing.unit ? UNITLESS_UNITS.has(ing.unit) : false;
+        return (
+          <div
+            key={i}
+            className="grid grid-cols-[70px_90px_1fr_auto] sm:grid-cols-[80px_100px_1fr_auto] gap-2 items-center"
           >
-            ×
-          </button>
-        </div>
-      ))}
+            <input
+              type="number"
+              inputMode="decimal"
+              min={0}
+              step="0.25"
+              placeholder="qty"
+              disabled={unitless}
+              className={inputCls + (unitless ? ' opacity-40' : '')}
+              value={ing.amount ?? ''}
+              onChange={(e) =>
+                update(i, {
+                  amount: e.target.value === '' ? null : Number(e.target.value),
+                })
+              }
+            />
+            <select
+              className={inputCls}
+              value={ing.unit ?? ''}
+              onChange={(e) => handleUnitChange(i, e.target.value)}
+              aria-label="Unit"
+            >
+              <option value="">—</option>
+              {UNITS.map((u) => (
+                <option key={u} value={u}>
+                  {UNIT_LABELS[u]}
+                </option>
+              ))}
+            </select>
+            <input
+              type="text"
+              placeholder="ingredient (e.g. chicken breast)"
+              list={datalistId}
+              autoComplete="off"
+              spellCheck
+              className={inputCls}
+              value={ing.name}
+              onChange={(e) => update(i, { name: e.target.value })}
+            />
+            <button
+              type="button"
+              onClick={() => remove(i)}
+              className="text-zinc-500 hover:text-coral-400 text-lg leading-none w-7 h-7 grid place-items-center"
+              aria-label="Remove ingredient"
+            >
+              ×
+            </button>
+          </div>
+        );
+      })}
+
       <button
         type="button"
         onClick={add}

--- a/src/components/InstructionsEditor.tsx
+++ b/src/components/InstructionsEditor.tsx
@@ -1,20 +1,24 @@
 'use client';
+import { Instruction, Ingredient, ingredientName } from '@/types';
 
 interface Props {
-  steps: string[];
-  onChange: (steps: string[]) => void;
+  steps: Instruction[];
+  /** Recipe ingredient list — drives the per-step ingredient chip picker. */
+  ingredients: Ingredient[];
+  onChange: (steps: Instruction[]) => void;
 }
 
 const inputCls =
   'flex-1 bg-zinc-900 border border-zinc-700 rounded-md px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-coral-400 focus:border-transparent';
 
-export default function InstructionsEditor({ steps, onChange }: Props) {
-  const update = (i: number, val: string) => {
+export default function InstructionsEditor({ steps, ingredients, onChange }: Props) {
+  const update = (i: number, patch: Partial<Instruction>) => {
     const next = steps.slice();
-    next[i] = val;
+    next[i] = { ...next[i], ...patch };
     onChange(next);
   };
-  const add = () => onChange([...steps, '']);
+  const add = () =>
+    onChange([...steps, { text: '', ingredientIndexes: [] }]);
   const remove = (i: number) => onChange(steps.filter((_, idx) => idx !== i));
   const move = (i: number, dir: -1 | 1) => {
     const j = i + dir;
@@ -23,56 +27,99 @@ export default function InstructionsEditor({ steps, onChange }: Props) {
     [next[i], next[j]] = [next[j], next[i]];
     onChange(next);
   };
+  const toggleIndex = (i: number, idx: number) => {
+    const have = new Set(steps[i].ingredientIndexes);
+    if (have.has(idx)) have.delete(idx);
+    else have.add(idx);
+    update(i, { ingredientIndexes: Array.from(have).sort((a, b) => a - b) });
+  };
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-3">
       {steps.length === 0 && (
         <div className="text-xs text-zinc-500 italic">
           No steps yet. Add your first instruction ↓
         </div>
       )}
-      {steps.map((step, i) => (
-        <div key={i} className="flex items-start gap-2">
-          <span className="mt-2 w-6 h-6 rounded-full bg-coral-500/20 text-coral-400 text-xs grid place-items-center font-bold flex-shrink-0">
-            {i + 1}
-          </span>
-          <textarea
-            rows={1}
-            placeholder={`Step ${i + 1}`}
-            className={inputCls + ' resize-y min-h-[36px]'}
-            value={step}
-            onChange={(e) => update(i, e.target.value)}
-          />
-          <div className="flex flex-col gap-0.5">
-            <button
-              type="button"
-              onClick={() => move(i, -1)}
-              disabled={i === 0}
-              className="text-zinc-500 hover:text-zinc-200 disabled:opacity-30 text-xs w-6 h-4 leading-none"
-              aria-label="Move up"
-            >
-              ▲
-            </button>
-            <button
-              type="button"
-              onClick={() => move(i, 1)}
-              disabled={i === steps.length - 1}
-              className="text-zinc-500 hover:text-zinc-200 disabled:opacity-30 text-xs w-6 h-4 leading-none"
-              aria-label="Move down"
-            >
-              ▼
-            </button>
-          </div>
-          <button
-            type="button"
-            onClick={() => remove(i)}
-            className="text-zinc-500 hover:text-coral-400 text-lg leading-none w-7 h-7 grid place-items-center mt-0.5"
-            aria-label="Remove step"
+      {steps.map((step, i) => {
+        const selected = new Set(step.ingredientIndexes);
+        return (
+          <div
+            key={i}
+            className="rounded-lg border border-zinc-800 bg-zinc-900/40 p-2 space-y-2"
           >
-            ×
-          </button>
-        </div>
-      ))}
+            <div className="flex items-start gap-2">
+              <span className="mt-2 w-6 h-6 rounded-full bg-coral-500/20 text-coral-400 text-xs grid place-items-center font-bold flex-shrink-0">
+                {i + 1}
+              </span>
+              <textarea
+                rows={1}
+                placeholder={`Step ${i + 1}`}
+                className={inputCls + ' resize-y min-h-[36px]'}
+                value={step.text}
+                onChange={(e) => update(i, { text: e.target.value })}
+              />
+              <div className="flex flex-col gap-0.5">
+                <button
+                  type="button"
+                  onClick={() => move(i, -1)}
+                  disabled={i === 0}
+                  className="text-zinc-500 hover:text-zinc-200 disabled:opacity-30 text-xs w-6 h-4 leading-none"
+                  aria-label="Move up"
+                >
+                  ▲
+                </button>
+                <button
+                  type="button"
+                  onClick={() => move(i, 1)}
+                  disabled={i === steps.length - 1}
+                  className="text-zinc-500 hover:text-zinc-200 disabled:opacity-30 text-xs w-6 h-4 leading-none"
+                  aria-label="Move down"
+                >
+                  ▼
+                </button>
+              </div>
+              <button
+                type="button"
+                onClick={() => remove(i)}
+                className="text-zinc-500 hover:text-coral-400 text-lg leading-none w-7 h-7 grid place-items-center mt-0.5"
+                aria-label="Remove step"
+              >
+                ×
+              </button>
+            </div>
+
+            {ingredients.length > 0 && (
+              <div className="pl-8">
+                <div className="text-[10px] uppercase tracking-wider text-zinc-500 mb-1">
+                  Ingredients used in this step
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  {ingredients.map((ing, idx) => {
+                    const label = ingredientName(ing).trim();
+                    if (!label) return null;
+                    const on = selected.has(idx);
+                    return (
+                      <button
+                        key={`${idx}-${label}`}
+                        type="button"
+                        onClick={() => toggleIndex(i, idx)}
+                        className={`text-[11px] px-2 py-0.5 rounded-full border transition ${
+                          on
+                            ? 'bg-coral-500/20 border-coral-500/50 text-coral-200'
+                            : 'bg-zinc-900 border-zinc-800 text-zinc-400 hover:border-zinc-700 hover:text-zinc-200'
+                        }`}
+                      >
+                        {label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      })}
       <button
         type="button"
         onClick={add}

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -1,23 +1,14 @@
 'use client';
 import Link from 'next/link';
-import { Recipe } from '@/types';
+import { Recipe, TAG_LABELS } from '@/types';
 import { PublicUserProfile } from '@/lib/users';
 import { PrivacyBadge } from './PrivacyBadge';
 import LikeButton from './LikeButton';
 
 interface Props {
   recipe: Recipe;
-  /** Public profile of the recipe author, when resolved. Card renders
-   *  a fallback (`@handle` or "a chef") when not provided yet. */
+  /** Public profile of the recipe author, when resolved. */
   author?: PublicUserProfile | null;
-}
-
-function diffColor(d: string) {
-  return d === 'Easy'
-    ? 'text-emerald-400'
-    : d === 'Medium'
-    ? 'text-amber-400'
-    : 'text-coral-400';
 }
 
 export function RecipeCard({ recipe, author }: Props) {
@@ -25,6 +16,9 @@ export function RecipeCard({ recipe, author }: Props) {
   const name = author?.displayName ?? null;
   const avatarUrl = author?.avatarUrl ?? null;
   const initial = (name || handle || '?').charAt(0).toUpperCase();
+  // Difficulty is 1..5 going forward, but back-compat for any unmigrated rows.
+  const diff = typeof recipe.difficulty === 'number' ? recipe.difficulty : 3;
+  const tags = recipe.tags ?? [];
   return (
     <Link
       href={`/recipes/view?id=${encodeURIComponent(recipe.recipeId)}`}
@@ -35,14 +29,18 @@ export function RecipeCard({ recipe, author }: Props) {
           <h3 className="font-bold text-base truncate group-hover:text-coral-300 transition">
             {recipe.name}
           </h3>
-          <div className="text-xs flex items-center gap-1.5 mt-0.5">
-            <span className={`font-semibold ${diffColor(recipe.difficulty)}`}>
-              {recipe.difficulty}
-            </span>
+          <div className="text-xs flex items-center gap-1.5 mt-0.5 text-zinc-400">
+            <DifficultyDots value={diff} />
             {recipe.timeMinutes > 0 && (
               <>
                 <span className="text-zinc-700">·</span>
-                <span className="text-zinc-400">{recipe.timeMinutes}m</span>
+                <span>{recipe.timeMinutes}m</span>
+              </>
+            )}
+            {recipe.servings > 0 && (
+              <>
+                <span className="text-zinc-700">·</span>
+                <span>{recipe.servings} {recipe.servings === 1 ? 'serv' : 'servs'}</span>
               </>
             )}
           </div>
@@ -54,10 +52,22 @@ export function RecipeCard({ recipe, author }: Props) {
         <p className="text-xs text-zinc-400 line-clamp-2">{recipe.description}</p>
       )}
 
-      {recipe.proteinSource && (
-        <span className="inline-block bg-coral-500/15 text-coral-300 text-xs px-2 py-0.5 rounded-full">
-          {recipe.proteinSource}
-        </span>
+      {tags.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {tags.slice(0, 4).map((t) => (
+            <span
+              key={t}
+              className="inline-block bg-zinc-800/80 text-zinc-300 text-[10px] px-1.5 py-0.5 rounded-full"
+            >
+              {TAG_LABELS[t] ?? t}
+            </span>
+          ))}
+          {tags.length > 4 && (
+            <span className="inline-block text-[10px] text-zinc-500 px-1">
+              +{tags.length - 4}
+            </span>
+          )}
+        </div>
       )}
 
       <div className="flex items-center justify-between pt-1 border-t border-zinc-800/60 gap-2">
@@ -72,7 +82,7 @@ export function RecipeCard({ recipe, author }: Props) {
             <span className="text-zinc-300 font-semibold">{recipe.cookCount}</span>{' '}
             {recipe.cookCount === 1 ? 'cook' : 'cooks'}
           </span>
-          {recipe.ratingCount > 0 && (
+          {recipe.ratingCount > 0 && recipe.avgRating != null && (
             <span className="flex items-center gap-1 shrink-0">
               <span className="text-coral-300">★</span>
               <span className="text-zinc-300 font-semibold">
@@ -107,5 +117,21 @@ export function RecipeCard({ recipe, author }: Props) {
         )}
       </div>
     </Link>
+  );
+}
+
+function DifficultyDots({ value }: { value: number }) {
+  const v = Math.max(1, Math.min(5, Math.round(value)));
+  return (
+    <span className="inline-flex items-center gap-0.5" aria-label={`Difficulty ${v} of 5`}>
+      {[1, 2, 3, 4, 5].map((n) => (
+        <span
+          key={n}
+          className={`h-1.5 w-1.5 rounded-full ${
+            n <= v ? 'bg-coral-400' : 'bg-zinc-700'
+          }`}
+        />
+      ))}
+    </span>
   );
 }

--- a/src/components/RecipeForm.tsx
+++ b/src/components/RecipeForm.tsx
@@ -1,25 +1,53 @@
 'use client';
 import { useState } from 'react';
-import { Difficulty, Ingredient, Macros, Privacy, Recipe, normalizeIngredient } from '@/types';
+import {
+  Difficulty,
+  Ingredient,
+  Instruction,
+  Macros,
+  MacrosScope,
+  Privacy,
+  ProteinType,
+  PROTEIN_TYPES,
+  PROTEIN_LABELS,
+  Recipe,
+  Tag,
+  TAG_GROUPS,
+  TAG_LABELS,
+  normalizeIngredient,
+  normalizeInstruction,
+} from '@/types';
 import IngredientsEditor from './IngredientsEditor';
 import InstructionsEditor from './InstructionsEditor';
+import { rememberIngredient } from '@/lib/common-ingredients';
 
-const DIFFICULTIES: Difficulty[] = ['Easy', 'Medium', 'Hard'];
 const PRIVACIES: { value: Privacy; label: string; hint: string }[] = [
   { value: 'private', label: 'Private', hint: 'Only you can see it.' },
   { value: 'friends', label: 'Friends', hint: 'Visible to your accepted friends.' },
   { value: 'public', label: 'Public', hint: 'Anyone can find and view it.' },
 ];
 
+const DIFFICULTY_LABELS: Record<Difficulty, string> = {
+  1: 'Beginner',
+  2: 'Easy',
+  3: 'Medium',
+  4: 'Hard',
+  5: 'Expert',
+};
+
 export interface RecipeFormValues {
   name: string;
   description: string;
   timeMinutes: number;
+  servings: number;
   difficulty: Difficulty;
   proteinSource: string;
+  proteinTypes: ProteinType[];
+  tags: Tag[];
   ingredients: Ingredient[];
-  instructions: string[];
+  instructions: Instruction[];
   macros: Macros;
+  macrosScope: MacrosScope;
   privacy: Privacy;
 }
 
@@ -38,19 +66,38 @@ export function RecipeForm({ initial, submitLabel, onSubmit }: Props) {
   const [name, setName] = useState(initial?.name ?? '');
   const [description, setDescription] = useState(initial?.description ?? '');
   const [timeMinutes, setTimeMinutes] = useState(initial?.timeMinutes ?? 30);
-  const [difficulty, setDifficulty] = useState<Difficulty>(initial?.difficulty ?? 'Medium');
+  const [servings, setServings] = useState(initial?.servings ?? 1);
+  const [difficulty, setDifficulty] = useState<Difficulty>(
+    (initial?.difficulty as Difficulty) ?? 3,
+  );
   const [proteinSource, setProteinSource] = useState(initial?.proteinSource ?? '');
+  const [proteinTypes, setProteinTypes] = useState<ProteinType[]>(
+    initial?.proteinTypes ?? [],
+  );
+  const [tags, setTags] = useState<Tag[]>(initial?.tags ?? []);
   const [ingredients, setIngredients] = useState<Ingredient[]>(
     (initial?.ingredients ?? []).map(normalizeIngredient),
   );
-  const [instructions, setInstructions] = useState<string[]>(initial?.instructions ?? []);
+  const [instructions, setInstructions] = useState<Instruction[]>(
+    (initial?.instructions ?? []).map(normalizeInstruction),
+  );
   const [calories, setCalories] = useState(initial?.macros?.calories ?? 0);
   const [protein, setProtein] = useState(initial?.macros?.protein ?? 0);
   const [carbs, setCarbs] = useState(initial?.macros?.carbs ?? 0);
   const [fat, setFat] = useState(initial?.macros?.fat ?? 0);
+  const [macrosScope, setMacrosScope] = useState<MacrosScope>(
+    initial?.macrosScope ?? 'per-recipe',
+  );
   const [privacy, setPrivacy] = useState<Privacy>(initial?.privacy ?? 'private');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const toggleProtein = (p: ProteinType) =>
+    setProteinTypes((prev) =>
+      prev.includes(p) ? prev.filter((x) => x !== p) : [...prev, p],
+    );
+  const toggleTag = (t: Tag) =>
+    setTags((prev) => (prev.includes(t) ? prev.filter((x) => x !== t) : [...prev, t]));
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -58,15 +105,22 @@ export function RecipeForm({ initial, submitLabel, onSubmit }: Props) {
     setSubmitting(true);
     setError(null);
     try {
+      const cleanedIngredients = ingredients.filter((i) => i.name.trim());
+      // Remember unique ingredient names for future autocomplete.
+      cleanedIngredients.forEach((i) => rememberIngredient(i.name));
       await onSubmit({
         name: name.trim(),
         description: description.trim(),
         timeMinutes,
+        servings,
         difficulty,
         proteinSource: proteinSource.trim(),
-        ingredients: ingredients.filter((i) => i.name.trim()),
-        instructions: instructions.filter((s) => s.trim()),
+        proteinTypes,
+        tags,
+        ingredients: cleanedIngredients,
+        instructions: instructions.filter((s) => s.text.trim()),
         macros: { calories, protein, carbs, fat },
+        macrosScope,
         privacy,
       });
     } catch (err) {
@@ -99,11 +153,12 @@ export function RecipeForm({ initial, submitLabel, onSubmit }: Props) {
         />
       </div>
 
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
         <div>
           <label className={labelCls}>Time (min)</label>
           <input
             type="number"
+            inputMode="numeric"
             className={inputCls}
             value={timeMinutes}
             onChange={(e) => setTimeMinutes(+e.target.value)}
@@ -111,27 +166,82 @@ export function RecipeForm({ initial, submitLabel, onSubmit }: Props) {
           />
         </div>
         <div>
-          <label className={labelCls}>Difficulty</label>
-          <select
+          <label className={labelCls}>Servings</label>
+          <input
+            type="number"
+            inputMode="numeric"
             className={inputCls}
-            value={difficulty}
-            onChange={(e) => setDifficulty(e.target.value as Difficulty)}
-          >
-            {DIFFICULTIES.map((d) => (
-              <option key={d}>{d}</option>
-            ))}
-          </select>
+            value={servings}
+            onChange={(e) => setServings(Math.max(1, +e.target.value || 1))}
+            min={1}
+            max={50}
+          />
+        </div>
+        <div className="col-span-2 sm:col-span-1">
+          <label className={labelCls}>Difficulty: {DIFFICULTY_LABELS[difficulty]}</label>
+          <DifficultyPicker value={difficulty} onChange={setDifficulty} />
         </div>
       </div>
 
       <div>
-        <label className={labelCls}>Protein source</label>
+        <label className={labelCls}>Protein</label>
+        <div className="flex flex-wrap gap-1.5">
+          {PROTEIN_TYPES.map((p) => {
+            const on = proteinTypes.includes(p);
+            return (
+              <button
+                key={p}
+                type="button"
+                onClick={() => toggleProtein(p)}
+                className={`text-xs px-2.5 py-1 rounded-full border transition ${
+                  on
+                    ? 'bg-coral-500/20 border-coral-500/50 text-coral-200'
+                    : 'bg-zinc-900 border-zinc-800 text-zinc-400 hover:border-zinc-700 hover:text-zinc-200'
+                }`}
+              >
+                {PROTEIN_LABELS[p]}
+              </button>
+            );
+          })}
+        </div>
         <input
-          className={inputCls}
+          className={inputCls + ' mt-2'}
           value={proteinSource}
           onChange={(e) => setProteinSource(e.target.value)}
-          placeholder="Chicken, Tofu, Beef…"
+          placeholder="Optional free-text label (e.g. Bone-in chicken thigh)"
         />
+      </div>
+
+      <div>
+        <label className={labelCls}>Tags</label>
+        <div className="space-y-2">
+          {TAG_GROUPS.map((group) => (
+            <div key={group.label}>
+              <div className="text-[10px] uppercase tracking-wider text-zinc-500 mb-1">
+                {group.label}
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {group.tags.map((t) => {
+                  const on = tags.includes(t);
+                  return (
+                    <button
+                      key={t}
+                      type="button"
+                      onClick={() => toggleTag(t)}
+                      className={`text-xs px-2.5 py-1 rounded-full border transition ${
+                        on
+                          ? 'bg-coral-500/20 border-coral-500/50 text-coral-200'
+                          : 'bg-zinc-900 border-zinc-800 text-zinc-400 hover:border-zinc-700 hover:text-zinc-200'
+                      }`}
+                    >
+                      {TAG_LABELS[t]}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
       </div>
 
       <div>
@@ -141,11 +251,33 @@ export function RecipeForm({ initial, submitLabel, onSubmit }: Props) {
 
       <div>
         <label className={labelCls}>Instructions</label>
-        <InstructionsEditor steps={instructions} onChange={setInstructions} />
+        <InstructionsEditor
+          steps={instructions}
+          ingredients={ingredients}
+          onChange={setInstructions}
+        />
       </div>
 
       <div>
-        <label className={labelCls}>Macros</label>
+        <div className="flex items-end justify-between gap-3 mb-2">
+          <label className={labelCls + ' mb-0'}>Macros</label>
+          <div className="flex bg-zinc-900 border border-zinc-800 rounded-lg p-0.5 text-[11px] font-semibold">
+            {(['per-recipe', 'per-serving'] as MacrosScope[]).map((s) => (
+              <button
+                key={s}
+                type="button"
+                onClick={() => setMacrosScope(s)}
+                className={`px-2.5 py-1 rounded-md transition ${
+                  macrosScope === s
+                    ? 'bg-zinc-800 text-coral-300'
+                    : 'text-zinc-400 hover:text-zinc-200'
+                }`}
+              >
+                {s === 'per-serving' ? 'per serving' : 'per recipe'}
+              </button>
+            ))}
+          </div>
+        </div>
         <div className="grid grid-cols-4 gap-2">
           {(
             [
@@ -161,6 +293,7 @@ export function RecipeForm({ initial, submitLabel, onSubmit }: Props) {
               </span>
               <input
                 type="number"
+                inputMode="numeric"
                 className={inputCls}
                 value={val}
                 onChange={(e) => setter(+e.target.value)}
@@ -217,5 +350,37 @@ export function RecipeForm({ initial, submitLabel, onSubmit }: Props) {
         {submitting ? 'Saving…' : submitLabel}
       </button>
     </form>
+  );
+}
+
+function DifficultyPicker({
+  value,
+  onChange,
+}: {
+  value: Difficulty;
+  onChange: (v: Difficulty) => void;
+}) {
+  return (
+    <div className="flex gap-1" role="radiogroup" aria-label="Difficulty">
+      {([1, 2, 3, 4, 5] as Difficulty[]).map((n) => {
+        const on = n <= value;
+        return (
+          <button
+            key={n}
+            type="button"
+            role="radio"
+            aria-checked={value === n}
+            onClick={() => onChange(n)}
+            className={`flex-1 min-w-0 h-9 rounded-md border transition focus:outline-none focus:ring-2 focus:ring-coral-400/50 ${
+              on
+                ? 'bg-coral-500/20 border-coral-500/50 text-coral-200'
+                : 'bg-zinc-900 border-zinc-800 text-zinc-500 hover:border-zinc-700'
+            }`}
+          >
+            <span className="text-sm font-bold">{n}</span>
+          </button>
+        );
+      })}
+    </div>
   );
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -50,11 +50,15 @@ export interface CreateRecipeInput {
   name: string;
   description?: string;
   timeMinutes?: number;
+  servings?: number;
   difficulty?: Recipe['difficulty'];
   proteinSource?: string;
+  proteinTypes?: Recipe['proteinTypes'];
+  tags?: Recipe['tags'];
   ingredients?: Recipe['ingredients'];
-  instructions?: string[];
+  instructions?: Recipe['instructions'];
   macros?: Recipe['macros'];
+  macrosScope?: Recipe['macrosScope'];
   privacy?: Recipe['privacy'];
 }
 
@@ -63,9 +67,18 @@ export type EditRecipeInput = Partial<CreateRecipeInput>;
 export interface RateRecipeResult {
   recipeId: string;
   userId: string;
-  rating: number;
-  avgRating: number;
+  rating: number | null;
+  spiciness: number | null;
+  avgRating: number | null;
   ratingCount: number;
+  spicinessAvg: number | null;
+  spicinessCount: number;
+}
+
+export interface ListPublicFilters {
+  tags?: Recipe['tags'];
+  proteinTypes?: Recipe['proteinTypes'];
+  maxTimeMinutes?: number;
 }
 
 export interface RecipesPublicPage {
@@ -106,7 +119,7 @@ export const recipesApi = {
   list: (authorUserId?: string): Promise<Recipe[]> =>
     apiPost<Recipe[]>('/recipes/list', authorUserId ? { authorUserId } : undefined),
   /** Global feed of `privacy = 'public'` recipes, newest first. */
-  listPublic: (opts?: { limit?: number; cursor?: string }): Promise<RecipesPublicPage> =>
+  listPublic: (opts?: { limit?: number; cursor?: string } & ListPublicFilters): Promise<RecipesPublicPage> =>
     apiPost<RecipesPublicPage>('/recipes/list-public', opts ?? {}),
   create: (body: CreateRecipeInput): Promise<Recipe> =>
     apiPost<Recipe>('/recipes/create', body),
@@ -116,8 +129,11 @@ export const recipesApi = {
     apiPost<Recipe>('/recipes/edit', { recipeId, ...fields }),
   delete: (recipeId: string): Promise<void> =>
     apiPost<void>('/recipes/delete', { recipeId }),
-  rate: (recipeId: string, rating: number): Promise<RateRecipeResult> =>
-    apiPost<RateRecipeResult>('/recipes/rate', { recipeId, rating }),
+  rate: (
+    recipeId: string,
+    axes: { rating?: number; spiciness?: number },
+  ): Promise<RateRecipeResult> =>
+    apiPost<RateRecipeResult>('/recipes/rate', { recipeId, ...axes }),
   like: (recipeId: string): Promise<{ recipeId: string; likeCount: number; likedByMe: boolean }> =>
     apiPost('/recipes/like', { recipeId }),
 };

--- a/src/lib/common-ingredients.ts
+++ b/src/lib/common-ingredients.ts
@@ -1,0 +1,88 @@
+/**
+ * Curated staple-pantry list for the IngredientsEditor autocomplete.
+ * Kept short and English-only — Phase B (recipe import) will expand
+ * the vocabulary as users paste recipes from real sources.
+ *
+ * Pair with a localStorage-backed memory of the user's own past
+ * ingredients (see useIngredientHistory) so the suggestion list grows
+ * with usage.
+ */
+export const COMMON_INGREDIENTS: readonly string[] = [
+  // Aromatics
+  'onion', 'red onion', 'shallot', 'garlic', 'ginger', 'scallion', 'leek',
+  // Herbs
+  'basil', 'cilantro', 'parsley', 'mint', 'rosemary', 'thyme', 'oregano', 'sage', 'dill', 'chives', 'bay leaf',
+  // Spices & dry
+  'salt', 'pepper', 'black pepper', 'red pepper flakes', 'paprika', 'smoked paprika', 'cumin', 'coriander', 'turmeric', 'cinnamon', 'nutmeg', 'cardamom', 'clove', 'allspice', 'chili powder', 'curry powder', 'garam masala', 'fennel seed', 'mustard seed', 'sesame seed', 'star anise', 'vanilla extract',
+  // Oils & fats
+  'olive oil', 'extra virgin olive oil', 'vegetable oil', 'canola oil', 'sesame oil', 'avocado oil', 'butter', 'unsalted butter', 'ghee', 'lard', 'coconut oil',
+  // Vinegars & condiments
+  'soy sauce', 'tamari', 'fish sauce', 'oyster sauce', 'hoisin sauce', 'miso', 'rice vinegar', 'apple cider vinegar', 'red wine vinegar', 'balsamic vinegar', 'white wine vinegar', 'sriracha', 'gochujang', 'tahini', 'dijon mustard', 'mayonnaise', 'ketchup', 'worcestershire sauce', 'hot sauce', 'lemon juice', 'lime juice',
+  // Dairy & alt
+  'milk', 'whole milk', 'heavy cream', 'half and half', 'sour cream', 'yogurt', 'greek yogurt', 'cream cheese', 'cottage cheese', 'parmesan', 'mozzarella', 'cheddar', 'feta', 'goat cheese', 'ricotta', 'oat milk', 'almond milk', 'coconut milk',
+  // Eggs
+  'egg', 'egg yolk', 'egg white',
+  // Proteins
+  'chicken breast', 'chicken thigh', 'whole chicken', 'ground chicken', 'ground beef', 'ground turkey', 'ground pork', 'beef', 'steak', 'sirloin', 'ribeye', 'skirt steak', 'flank steak', 'pork chop', 'pork tenderloin', 'bacon', 'pancetta', 'sausage', 'ham', 'salmon', 'cod', 'tuna', 'shrimp', 'scallop', 'tilapia', 'halibut', 'mahi mahi', 'tofu', 'firm tofu', 'silken tofu', 'tempeh', 'seitan', 'chickpeas', 'lentils', 'black beans', 'kidney beans', 'pinto beans', 'cannellini beans', 'edamame',
+  // Vegetables
+  'tomato', 'cherry tomato', 'roma tomato', 'cucumber', 'bell pepper', 'red bell pepper', 'green bell pepper', 'yellow bell pepper', 'jalapeno', 'serrano', 'poblano', 'carrot', 'celery', 'potato', 'sweet potato', 'mushroom', 'cremini mushroom', 'shiitake mushroom', 'spinach', 'kale', 'arugula', 'romaine', 'iceberg lettuce', 'cabbage', 'napa cabbage', 'broccoli', 'cauliflower', 'zucchini', 'yellow squash', 'eggplant', 'green bean', 'asparagus', 'corn', 'pea', 'snap pea', 'snow pea', 'beet', 'radish', 'fennel', 'butternut squash', 'acorn squash', 'pumpkin',
+  // Fruits
+  'apple', 'banana', 'lemon', 'lime', 'orange', 'grapefruit', 'avocado', 'strawberry', 'blueberry', 'raspberry', 'blackberry', 'pineapple', 'mango', 'pear', 'peach', 'plum', 'grape', 'pomegranate', 'watermelon', 'cherry',
+  // Pantry / starches
+  'rice', 'white rice', 'brown rice', 'jasmine rice', 'basmati rice', 'arborio rice', 'sushi rice', 'quinoa', 'couscous', 'farro', 'barley', 'orzo', 'pasta', 'spaghetti', 'penne', 'fettuccine', 'rigatoni', 'macaroni', 'lasagna noodle', 'ramen noodle', 'rice noodle', 'soba', 'udon', 'tortilla', 'flour tortilla', 'corn tortilla', 'pita', 'naan', 'bread', 'sourdough', 'baguette', 'breadcrumb', 'panko',
+  // Baking
+  'flour', 'all-purpose flour', 'bread flour', 'whole wheat flour', 'almond flour', 'sugar', 'brown sugar', 'powdered sugar', 'honey', 'maple syrup', 'molasses', 'baking powder', 'baking soda', 'yeast', 'cocoa powder', 'chocolate chip', 'dark chocolate',
+  // Nuts & seeds
+  'almond', 'cashew', 'pecan', 'walnut', 'pistachio', 'peanut', 'pine nut', 'sunflower seed', 'pumpkin seed', 'chia seed', 'flax seed', 'sesame', 'peanut butter', 'almond butter',
+  // Stocks
+  'chicken stock', 'beef stock', 'vegetable stock', 'water',
+  // Wine
+  'white wine', 'red wine', 'sake', 'mirin', 'sherry',
+];
+
+/**
+ * localStorage-backed history of the user's own ingredient names.
+ * Keeps the autocomplete personal: once you type 'gochujang' once,
+ * it shows up in suggestions on every later recipe.
+ */
+const HISTORY_KEY = 'xomappetit:ingredient-history:v1';
+const HISTORY_LIMIT = 200;
+
+export function loadIngredientHistory(): string[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = window.localStorage.getItem(HISTORY_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((s) => typeof s === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+export function rememberIngredient(name: string): void {
+  if (typeof window === 'undefined') return;
+  const cleaned = name.trim().toLowerCase();
+  if (!cleaned || cleaned.length > 60) return;
+  const current = loadIngredientHistory();
+  const next = [cleaned, ...current.filter((s) => s !== cleaned)].slice(0, HISTORY_LIMIT);
+  try {
+    window.localStorage.setItem(HISTORY_KEY, JSON.stringify(next));
+  } catch {
+    // storage full or disabled — fine, we just lose local memory.
+  }
+}
+
+/** Combined suggestion list (user history first, then curated staples). */
+export function ingredientSuggestions(): string[] {
+  const history = loadIngredientHistory();
+  const seen = new Set(history);
+  const merged = [...history];
+  for (const s of COMMON_INGREDIENTS) {
+    if (!seen.has(s)) {
+      merged.push(s);
+      seen.add(s);
+    }
+  }
+  return merged;
+}

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -250,9 +250,9 @@ export function useRecipe(recipeId: string | null) {
     isLoading,
     error,
     refresh: () => mutateOne(),
-    rate: async (rating: number) => {
+    rate: async (axes: { rating?: number; spiciness?: number }) => {
       if (!recipeId) return;
-      await recipesApi.rate(recipeId, rating);
+      await recipesApi.rate(recipeId, axes);
       mutateOne();
       mutate(RECIPES_KEY);
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,170 @@
+// ---------- Units ----------
+
+export type Unit =
+  | 'count' | 'g' | 'kg' | 'oz' | 'lb' | 'ml' | 'l'
+  | 'cup' | 'tbsp' | 'tsp' | 'clove' | 'pinch' | 'dash'
+  | 'slice' | 'can' | 'to-taste';
+
+export const UNITS: Unit[] = [
+  'count', 'g', 'kg', 'oz', 'lb', 'ml', 'l',
+  'cup', 'tbsp', 'tsp', 'clove', 'pinch', 'dash',
+  'slice', 'can', 'to-taste',
+];
+
+export const UNIT_LABELS: Record<Unit, string> = {
+  count: 'count',
+  g: 'g',
+  kg: 'kg',
+  oz: 'oz',
+  lb: 'lb',
+  ml: 'ml',
+  l: 'L',
+  cup: 'cup',
+  tbsp: 'tbsp',
+  tsp: 'tsp',
+  clove: 'clove',
+  pinch: 'pinch',
+  dash: 'dash',
+  slice: 'slice',
+  can: 'can',
+  'to-taste': 'to taste',
+};
+
+export const UNITLESS_UNITS = new Set<Unit>(['to-taste', 'pinch', 'dash']);
+
+// Sensible default amount when the user picks a unit. Used to prefill the
+// amount input so 'tsp' becomes '1 tsp' instead of leaving an empty box.
+export const UNIT_DEFAULT_AMOUNTS: Partial<Record<Unit, number>> = {
+  count: 1,
+  g: 100,
+  kg: 1,
+  oz: 4,
+  lb: 1,
+  ml: 250,
+  l: 1,
+  cup: 1,
+  tbsp: 1,
+  tsp: 1,
+  clove: 1,
+  slice: 1,
+  can: 1,
+};
+
+// ---------- Protein types ----------
+
+export type ProteinType =
+  | 'chicken' | 'beef' | 'pork' | 'turkey' | 'lamb'
+  | 'fish' | 'salmon' | 'tuna' | 'shrimp' | 'shellfish'
+  | 'tofu' | 'tempeh' | 'seitan'
+  | 'beans' | 'lentils' | 'chickpeas'
+  | 'eggs' | 'dairy' | 'nuts'
+  | 'none' | 'other';
+
+export const PROTEIN_TYPES: ProteinType[] = [
+  'chicken', 'beef', 'pork', 'turkey', 'lamb',
+  'fish', 'salmon', 'tuna', 'shrimp', 'shellfish',
+  'tofu', 'tempeh', 'seitan',
+  'beans', 'lentils', 'chickpeas',
+  'eggs', 'dairy', 'nuts',
+  'none', 'other',
+];
+
+export const PROTEIN_LABELS: Record<ProteinType, string> = {
+  chicken: 'Chicken',
+  beef: 'Beef',
+  pork: 'Pork',
+  turkey: 'Turkey',
+  lamb: 'Lamb',
+  fish: 'Fish',
+  salmon: 'Salmon',
+  tuna: 'Tuna',
+  shrimp: 'Shrimp',
+  shellfish: 'Shellfish',
+  tofu: 'Tofu',
+  tempeh: 'Tempeh',
+  seitan: 'Seitan',
+  beans: 'Beans',
+  lentils: 'Lentils',
+  chickpeas: 'Chickpeas',
+  eggs: 'Eggs',
+  dairy: 'Dairy',
+  nuts: 'Nuts',
+  none: 'None',
+  other: 'Other',
+};
+
+// ---------- Tags ----------
+
+export type Tag =
+  | 'vegetarian' | 'vegan' | 'gluten-free' | 'dairy-free' | 'nut-free'
+  | 'low-carb' | 'keto' | 'paleo' | 'high-protein' | 'low-calorie'
+  | 'spicy' | 'sweet' | 'savory'
+  | 'breakfast' | 'lunch' | 'dinner' | 'snack' | 'dessert' | 'appetizer'
+  | 'side' | 'main' | 'soup' | 'salad'
+  | 'baking' | 'grilling' | 'slow-cooker' | 'instant-pot' | 'one-pan' | 'no-cook'
+  | 'meal-prep' | 'quick' | 'date-night' | 'comfort' | 'kid-friendly';
+
+export const TAGS: Tag[] = [
+  'vegetarian', 'vegan', 'gluten-free', 'dairy-free', 'nut-free',
+  'low-carb', 'keto', 'paleo', 'high-protein', 'low-calorie',
+  'spicy', 'sweet', 'savory',
+  'breakfast', 'lunch', 'dinner', 'snack', 'dessert', 'appetizer',
+  'side', 'main', 'soup', 'salad',
+  'baking', 'grilling', 'slow-cooker', 'instant-pot', 'one-pan', 'no-cook',
+  'meal-prep', 'quick', 'date-night', 'comfort', 'kid-friendly',
+];
+
+export const TAG_LABELS: Record<Tag, string> = {
+  vegetarian: 'Vegetarian',
+  vegan: 'Vegan',
+  'gluten-free': 'Gluten-free',
+  'dairy-free': 'Dairy-free',
+  'nut-free': 'Nut-free',
+  'low-carb': 'Low-carb',
+  keto: 'Keto',
+  paleo: 'Paleo',
+  'high-protein': 'High-protein',
+  'low-calorie': 'Low-calorie',
+  spicy: 'Spicy',
+  sweet: 'Sweet',
+  savory: 'Savory',
+  breakfast: 'Breakfast',
+  lunch: 'Lunch',
+  dinner: 'Dinner',
+  snack: 'Snack',
+  dessert: 'Dessert',
+  appetizer: 'Appetizer',
+  side: 'Side',
+  main: 'Main',
+  soup: 'Soup',
+  salad: 'Salad',
+  baking: 'Baking',
+  grilling: 'Grilling',
+  'slow-cooker': 'Slow cooker',
+  'instant-pot': 'Instant pot',
+  'one-pan': 'One pan',
+  'no-cook': 'No cook',
+  'meal-prep': 'Meal prep',
+  quick: 'Quick',
+  'date-night': 'Date night',
+  comfort: 'Comfort',
+  'kid-friendly': 'Kid-friendly',
+};
+
+export const TAG_GROUPS: { label: string; tags: Tag[] }[] = [
+  { label: 'Diet', tags: ['vegetarian', 'vegan', 'gluten-free', 'dairy-free', 'nut-free', 'low-carb', 'keto', 'paleo', 'high-protein', 'low-calorie'] },
+  { label: 'Flavor', tags: ['spicy', 'sweet', 'savory'] },
+  { label: 'Meal', tags: ['breakfast', 'lunch', 'dinner', 'snack', 'dessert', 'appetizer', 'side', 'main', 'soup', 'salad'] },
+  { label: 'Method', tags: ['baking', 'grilling', 'slow-cooker', 'instant-pot', 'one-pan', 'no-cook'] },
+  { label: 'Vibe', tags: ['meal-prep', 'quick', 'date-night', 'comfort', 'kid-friendly'] },
+];
+
+// ---------- Core shapes ----------
+
 export interface Ingredient {
   name: string;
-  quantity: number | null;
-  unit: string | null;
+  amount: number | null;
+  unit: Unit | null;
 }
 
 export interface Macros {
@@ -11,31 +174,43 @@ export interface Macros {
   fat: number;
 }
 
-export type Difficulty = 'Easy' | 'Medium' | 'Hard';
+export type MacrosScope = 'per-serving' | 'per-recipe';
+
+export type Difficulty = 1 | 2 | 3 | 4 | 5;
 
 export type Privacy = 'public' | 'friends' | 'private';
+
+export interface Instruction {
+  text: string;
+  ingredientIndexes: number[];
+}
 
 export interface Recipe {
   recipeId: string;
   authorUserId: string;
-  /** Denormalized handle (lowercase) of the author at create time. May be null for older rows or federated users without a handle yet. */
+  /** Denormalized handle (lowercase) of the author at create time. */
   authorHandle: string | null;
   name: string;
   description: string;
   timeMinutes: number;
   difficulty: Difficulty;
+  servings: number;
+  /** Legacy free-text protein label — kept for back-compat / search. */
   proteinSource: string;
+  proteinTypes: ProteinType[];
+  tags: Tag[];
   ingredients: (string | Ingredient)[];
-  instructions: string[];
+  instructions: (string | Instruction)[];
   macros: Macros;
+  macrosScope: MacrosScope;
   privacy: Privacy;
   cookCount: number;
-  /** Total likes across all users. Denormalized — updated by recipes-like. */
   likeCount?: number;
-  /** Did the caller like this recipe? Only present on recipes-get / feed responses. */
   likedByMe?: boolean;
-  avgRating: number;
+  avgRating: number | null;
   ratingCount: number;
+  spicinessAvg: number | null;
+  spicinessCount: number;
   createdAt: string;
   updatedAt: string;
 }
@@ -62,19 +237,51 @@ export interface RecipeComment {
   createdAt: string;
 }
 
+// ---------- Helpers ----------
+
 export const ingredientName = (i: string | Ingredient): string =>
   typeof i === 'string' ? i : i.name;
 
 export const ingredientLabel = (i: string | Ingredient): string => {
   if (typeof i === 'string') return i;
   const parts: string[] = [];
-  if (i.quantity != null) parts.push(String(i.quantity));
-  if (i.unit) parts.push(i.unit);
+  if (i.amount != null) parts.push(formatAmount(i.amount));
+  if (i.unit) parts.push(UNIT_LABELS[i.unit] ?? i.unit);
   parts.push(i.name);
-  return parts.join(' ');
+  return parts.filter(Boolean).join(' ');
 };
 
 export const normalizeIngredient = (i: string | Ingredient): Ingredient => {
-  if (typeof i === 'string') return { name: i, quantity: null, unit: null };
-  return i;
+  if (typeof i === 'string') return { name: i, amount: null, unit: null };
+  // Tolerate legacy `quantity` field on read.
+  const legacy = i as Ingredient & { quantity?: number | null };
+  const amount = i.amount ?? legacy.quantity ?? null;
+  return { name: i.name, amount, unit: i.unit };
 };
+
+export const instructionText = (s: string | Instruction): string =>
+  typeof s === 'string' ? s : s.text;
+
+export const normalizeInstruction = (s: string | Instruction): Instruction => {
+  if (typeof s === 'string') return { text: s, ingredientIndexes: [] };
+  return { text: s.text, ingredientIndexes: s.ingredientIndexes ?? [] };
+};
+
+function formatAmount(n: number): string {
+  // Preserve quarter-fractions for the common cases (1/4, 1/2, 3/4) so
+  // recipes feel handwritten instead of "0.5 tbsp salt".
+  const whole = Math.floor(n);
+  const frac = n - whole;
+  const map: Record<string, string> = {
+    '0.25': '¼',
+    '0.5': '½',
+    '0.75': '¾',
+    '0.33': '⅓',
+    '0.67': '⅔',
+  };
+  const fracKey = frac.toFixed(2);
+  const sym = map[fracKey] ?? null;
+  if (sym && whole === 0) return sym;
+  if (sym) return `${whole}${sym}`;
+  return Number.isInteger(n) ? String(n) : String(n);
+}


### PR DESCRIPTION
## Summary
Frontend half of the recipe taxonomy work. Pairs with [xomappetit-backend#21](https://github.com/Xomware/xomappetit-backend/pull/21). Schema-additive — old recipes keep rendering since the read-side normalizer backfills new fields.

### Core type changes (\`src/types.ts\`)
- \`Ingredient\` shape becomes \`{ name, amount, unit }\` (legacy \`quantity\` field handled by \`normalizeIngredient\`)
- \`Instruction\` shape becomes \`{ text, ingredientIndexes[] }\` (legacy string steps handled by \`normalizeInstruction\`)
- \`Difficulty\` becomes \`1..5\`
- New enums + label maps: \`Unit\`, \`ProteinType\`, \`Tag\` (+ \`TAG_GROUPS\` for the filter / form panels)

### IngredientsEditor
- Quantity input + Unit \`<select>\` populated from the \`UNITS\` enum
- Datalist autocomplete fed by \`COMMON_INGREDIENTS\` (~200 staples) + a localStorage-backed history of past entries (\`loadIngredientHistory\`, \`rememberIngredient\`)
- Picking a unit prefills a sensible amount (\`tsp → 1\`, \`g → 100\`, \`cup → 1\`); \`to-taste\`/\`pinch\`/\`dash\` disable the amount

### InstructionsEditor
- Each step has a chip picker bound to the recipe's current ingredient list — Phase C ships here

### RecipeForm
- Servings field
- Difficulty 1..5 picker (5-segment fill)
- Protein chips (multi-select enum) + legacy free-text \`proteinSource\`
- Tag chips grouped by Diet / Flavor / Meal / Method / Vibe
- Macros scope toggle (per recipe vs per serving)

### RecipeCard + /recipes/view
- Difficulty rendered as a 5-dot indicator
- Tag chips + servings on the card
- Multi-axis ratings (overall + spiciness, both 5-star) on the detail page
- Per-step ingredient pills under each instruction
- Macros labeled with their scope

### /discover
- Inline filter panel: Protein + Tag chips (\`TAG_GROUPS\`)
- \`listPublic\` accepts \`tags\` / \`proteinTypes\` / \`maxTimeMinutes\`; refetches from page 1 on filter change
- Empty state distinguishes 'no public recipes' from 'no matches'

## Test plan
- [ ] Create a recipe: pick units, see suggested amounts populate; ingredients show up in autocomplete on the next recipe
- [ ] Set difficulty to 5 and a few tags — chips highlight, save, render on /discover and /recipes/view
- [ ] Tag chips per step appear in InstructionsEditor; toggle one and reload — ingredient pills show under the instruction in /recipes/view
- [ ] Rate overall + spiciness on a recipe — both averages update on the detail page
- [ ] /discover filter panel: pick 'spicy' + 'quick' — only recipes with both tags come back; clear works; pagination still loads more page-1 results