### PR TITLE
feat(import): URL/text recipe importer modal on /recipes/new

### DIFF
--- a/src/app/recipes/new/page.tsx
+++ b/src/app/recipes/new/page.tsx
@@ -1,15 +1,25 @@
 'use client';
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useRequireAuth } from '@/lib/auth-context';
 import { useRecipes } from '@/lib/hooks';
 import { RecipeForm, RecipeFormValues } from '@/components/RecipeForm';
+import ImportRecipeModal from '@/components/ImportRecipeModal';
+import { RecipeDraft } from '@/lib/api';
 import Loader from '@/components/Loader';
+import { Recipe } from '@/types';
 
 export default function NewRecipePage() {
   const router = useRouter();
   const { isAuthenticated, isLoading } = useRequireAuth();
   const { createRecipe } = useRecipes();
+  const [importOpen, setImportOpen] = useState(false);
+  const [initial, setInitial] = useState<Partial<Recipe> | undefined>(undefined);
+  const [importBanner, setImportBanner] = useState<string | null>(null);
+  // Bumping this remounts RecipeForm so the new initial values actually
+  // populate (the form seeds state in useState which only runs on mount).
+  const [formKey, setFormKey] = useState(0);
 
   if (isLoading || !isAuthenticated) {
     return <Loader fullscreen />;
@@ -18,6 +28,17 @@ export default function NewRecipePage() {
   const handleSubmit = async (values: RecipeFormValues) => {
     const created = await createRecipe(values);
     router.push(`/recipes/view?id=${encodeURIComponent(created.recipeId)}`);
+  };
+
+  const handleImported = (draft: RecipeDraft, source: 'json-ld' | 'claude') => {
+    setInitial(draft as Partial<Recipe>);
+    setFormKey((k) => k + 1);
+    setImportOpen(false);
+    setImportBanner(
+      source === 'json-ld'
+        ? 'Imported from the page metadata. Review and tweak before saving.'
+        : 'Imported via Claude. Numbers and tags are best-guess — give them a once-over.',
+    );
   };
 
   return (
@@ -34,10 +55,65 @@ export default function NewRecipePage() {
             ← Back
           </Link>
         </div>
+
+        <button
+          type="button"
+          onClick={() => setImportOpen(true)}
+          className="w-full flex items-center justify-between gap-3 bg-zinc-900/60 hover:bg-zinc-900 border border-zinc-800 hover:border-coral-500/50 rounded-xl p-4 text-left transition focus:outline-none focus:ring-2 focus:ring-coral-400/40"
+        >
+          <span className="flex items-center gap-3 min-w-0">
+            <span className="h-9 w-9 grid place-items-center rounded-md bg-coral-500/15 text-coral-300 shrink-0">
+              <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden="true">
+                <path
+                  d="M12 4v9m0 0-4-4m4 4 4-4M5 20h14"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  fill="none"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </span>
+            <span className="min-w-0">
+              <span className="block font-bold text-sm">Import from URL or text</span>
+              <span className="block text-[11px] text-zinc-500">
+                HelloFresh, AllRecipes, blogs, Instagram captions… we'll prefill the form.
+              </span>
+            </span>
+          </span>
+          <span className="text-coral-300 text-lg shrink-0" aria-hidden="true">›</span>
+        </button>
+
+        {importBanner && (
+          <div className="bg-coral-500/10 border border-coral-500/30 text-coral-200 text-xs rounded-lg px-3 py-2 flex items-start gap-2">
+            <span aria-hidden="true">✨</span>
+            <p className="flex-1">{importBanner}</p>
+            <button
+              type="button"
+              onClick={() => setImportBanner(null)}
+              aria-label="Dismiss"
+              className="text-coral-300/70 hover:text-coral-200 transition"
+            >
+              ×
+            </button>
+          </div>
+        )}
+
         <div className="rounded-2xl border border-zinc-800 bg-zinc-900/60 p-6 brand-stamp">
-          <RecipeForm submitLabel="Create recipe" onSubmit={handleSubmit} />
+          <RecipeForm
+            key={formKey}
+            initial={initial}
+            submitLabel="Create recipe"
+            onSubmit={handleSubmit}
+          />
         </div>
       </main>
+
+      <ImportRecipeModal
+        open={importOpen}
+        onClose={() => setImportOpen(false)}
+        onImported={handleImported}
+      />
     </div>
   );
 }

--- a/src/components/ImportRecipeModal.tsx
+++ b/src/components/ImportRecipeModal.tsx
@@ -1,0 +1,203 @@
+'use client';
+import { FormEvent, useEffect, useState } from 'react';
+import { recipesApi, RecipeDraft } from '@/lib/api';
+
+type Mode = 'url' | 'text';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  /** Called once the draft is ready. Caller decides where to use it. */
+  onImported: (draft: RecipeDraft, source: 'json-ld' | 'claude') => void;
+}
+
+/**
+ * Lightweight import sheet. Two modes:
+ *   - URL: paste a recipe URL → backend tries JSON-LD first, falls back to Claude
+ *   - Text: paste a caption / blog excerpt / OCR'd screenshot → Claude extracts
+ *
+ * On success the parent receives the draft and is responsible for prefilling
+ * its form. We don't auto-create — the user gets to review and tweak.
+ */
+export default function ImportRecipeModal({ open, onClose, onImported }: Props) {
+  const [mode, setMode] = useState<Mode>('url');
+  const [url, setUrl] = useState('');
+  const [text, setText] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setError(null);
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !busy) onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    const prev = document.documentElement.style.overflow;
+    document.documentElement.style.overflow = 'hidden';
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      document.documentElement.style.overflow = prev;
+    };
+  }, [open, busy, onClose]);
+
+  if (!open) return null;
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (busy) return;
+    setError(null);
+    setBusy(true);
+    try {
+      const result =
+        mode === 'url'
+          ? await recipesApi.importUrl(url.trim())
+          : await recipesApi.importText(text.trim());
+      onImported(result.draft, result.source);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Import failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/60 backdrop-blur-sm p-0 sm:p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Import recipe"
+    >
+      <button
+        type="button"
+        aria-label="Close"
+        onClick={onClose}
+        className="absolute inset-0 -z-10"
+        disabled={busy}
+      />
+      <div className="bg-zinc-950 w-full sm:max-w-lg rounded-t-2xl sm:rounded-2xl border border-zinc-800 shadow-2xl flex flex-col max-h-[90vh] overflow-hidden">
+        <header className="flex items-center justify-between p-4 border-b border-zinc-800">
+          <div>
+            <h2 className="font-display text-xl font-black uppercase tracking-wide">
+              Import recipe
+            </h2>
+            <p className="text-[11px] text-zinc-500 mt-0.5">
+              Paste a URL or social post — we'll prefill the form for you.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={busy}
+            aria-label="Close"
+            className="h-9 w-9 grid place-items-center rounded-md text-zinc-400 hover:text-white hover:bg-zinc-800 transition disabled:opacity-40"
+          >
+            <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden="true">
+              <path
+                fill="currentColor"
+                d="M6.4 4.99 12 10.6l5.6-5.61 1.41 1.41L13.41 12l5.6 5.6-1.41 1.41L12 13.41l-5.6 5.6-1.41-1.41L10.59 12l-5.6-5.6L6.4 4.99z"
+              />
+            </svg>
+          </button>
+        </header>
+
+        <div className="px-4 pt-3">
+          <div role="tablist" className="flex bg-zinc-900 border border-zinc-800 rounded-lg p-0.5 text-sm font-semibold">
+            {(['url', 'text'] as Mode[]).map((m) => (
+              <button
+                key={m}
+                role="tab"
+                aria-selected={mode === m}
+                type="button"
+                onClick={() => setMode(m)}
+                className={`flex-1 py-1.5 rounded-md transition ${
+                  mode === m
+                    ? 'bg-zinc-800 text-coral-300'
+                    : 'text-zinc-400 hover:text-zinc-200'
+                }`}
+              >
+                {m === 'url' ? 'From URL' : 'Paste text'}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <form onSubmit={submit} className="p-4 space-y-4 overflow-y-auto flex-1">
+          {mode === 'url' ? (
+            <div>
+              <label
+                htmlFor="import-url"
+                className="block text-xs font-semibold uppercase tracking-wider text-zinc-400 mb-1.5"
+              >
+                Recipe URL
+              </label>
+              <input
+                id="import-url"
+                type="url"
+                inputMode="url"
+                autoFocus
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                placeholder="https://www.allrecipes.com/recipe/..."
+                disabled={busy}
+                className="w-full bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-coral-400 focus:border-transparent disabled:opacity-50"
+              />
+              <p className="text-[11px] text-zinc-500 mt-1.5">
+                Works best with HelloFresh, AllRecipes, NYT Cooking, Bon Appétit, Serious Eats and most blogs.
+              </p>
+            </div>
+          ) : (
+            <div>
+              <label
+                htmlFor="import-text"
+                className="block text-xs font-semibold uppercase tracking-wider text-zinc-400 mb-1.5"
+              >
+                Recipe text
+              </label>
+              <textarea
+                id="import-text"
+                rows={8}
+                autoFocus
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+                placeholder="Paste an Instagram caption, TikTok description, or any plain-text recipe…"
+                disabled={busy}
+                className="w-full bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-coral-400 focus:border-transparent resize-y disabled:opacity-50"
+              />
+              <p className="text-[11px] text-zinc-500 mt-1.5">
+                Best for content without a clean URL — Instagram / TikTok captions, OCR'd screenshots, notes.
+              </p>
+            </div>
+          )}
+
+          {error && (
+            <div
+              role="alert"
+              className="text-xs text-coral-300 bg-coral-900/30 border border-coral-800 rounded-md px-3 py-2"
+            >
+              {error}
+            </div>
+          )}
+
+          <div className="flex gap-2 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={busy}
+              className="flex-1 bg-zinc-900 hover:bg-zinc-800 border border-zinc-800 text-zinc-200 py-2.5 rounded-lg text-sm font-semibold transition disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={busy || (mode === 'url' ? !url.trim() : text.trim().length < 30)}
+              className="flex-1 bg-gradient-to-r from-coral-500 to-coral-400 hover:from-coral-400 hover:to-coral-300 disabled:opacity-40 text-white py-2.5 rounded-lg text-sm font-bold uppercase tracking-wide transition shadow-lg shadow-coral-500/20 focus:outline-none focus:ring-2 focus:ring-coral-400/50"
+            >
+              {busy ? 'Importing…' : 'Import'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/components/RecipeForm.tsx
+++ b/src/components/RecipeForm.tsx
@@ -52,7 +52,8 @@ export interface RecipeFormValues {
 }
 
 interface Props {
-  initial?: Recipe;
+  /** Partial because import drafts and edit-existing both feed this. */
+  initial?: Partial<Recipe>;
   submitLabel: string;
   onSubmit: (values: RecipeFormValues) => Promise<void>;
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -81,6 +81,13 @@ export interface ListPublicFilters {
   maxTimeMinutes?: number;
 }
 
+export type RecipeDraft = CreateRecipeInput;
+
+export interface ImportRecipeResult {
+  draft: RecipeDraft;
+  source: 'json-ld' | 'claude';
+}
+
 export interface RecipesPublicPage {
   items: Recipe[];
   nextCursor: string | null;
@@ -136,6 +143,10 @@ export const recipesApi = {
     apiPost<RateRecipeResult>('/recipes/rate', { recipeId, ...axes }),
   like: (recipeId: string): Promise<{ recipeId: string; likeCount: number; likedByMe: boolean }> =>
     apiPost('/recipes/like', { recipeId }),
+  importUrl: (url: string): Promise<ImportRecipeResult> =>
+    apiPost<ImportRecipeResult>('/recipes/import-url', { url }),
+  importText: (text: string): Promise<ImportRecipeResult> =>
+    apiPost<ImportRecipeResult>('/recipes/import-text', { text }),
 };
 
 export const commentsApi = {


### PR DESCRIPTION
Frontend half of [xomappetit-backend#22](https://github.com/Xomware/xomappetit-backend/pull/22) + [xomappetit-infrastructure#26](https://github.com/Xomware/xomappetit-infrastructure/pull/26).

## Summary
- 'Import from URL or text' card above the New-recipe form
- Modal with two tabs: paste a URL, or paste text
- After import: form prefills with the draft and a banner flags JSON-LD vs Claude provenance so the user knows whether to scrutinize numbers
- Bottom-sheet on mobile, centered card on desktop

## Test plan
- [ ] Paste a HelloFresh URL → form prefills (banner says 'imported from page metadata')
- [ ] Paste a personal blog without JSON-LD → form prefills (banner says 'imported via Claude — give numbers a once-over')
- [ ] Paste an Instagram caption in 'Paste text' tab → form prefills
- [ ] Empty / invalid input shows an error message in the modal
- [ ] Esc closes the modal; clicking the backdrop closes it (unless an import is in flight)