### PR TITLE
feat(ratings): themed-icon ratings + sweetness/saltiness/richness axes

### DIFF
--- a/src/app/recipes/view/page.tsx
+++ b/src/app/recipes/view/page.tsx
@@ -6,7 +6,6 @@ import { useRequireAuth, useAuth } from '@/lib/auth-context';
 import { useRecipe } from '@/lib/hooks';
 import { RecipeForm, RecipeFormValues } from '@/components/RecipeForm';
 import { RecipeComments } from '@/components/RecipeComments';
-import { RatingStars } from '@/components/RatingStars';
 import LikeButton from '@/components/LikeButton';
 import { PrivacyBadge } from '@/components/PrivacyBadge';
 import {
@@ -21,6 +20,8 @@ import {
 } from '@/types';
 import { recipesApi } from '@/lib/api';
 import Loader from '@/components/Loader';
+import { IconRating, RATING_AXES, RatingAxisKey } from '@/components/IconRating';
+import { RateAxes } from '@/lib/api';
 
 export default function RecipeViewPage() {
   return (
@@ -38,8 +39,13 @@ function RecipeViewInner() {
   const { user } = useAuth();
   const { recipe, isLoading, error, refresh, edit, remove } = useRecipe(recipeId);
   const [editing, setEditing] = useState(false);
-  const [myRating, setMyRating] = useState<number>(0);
-  const [mySpiciness, setMySpiciness] = useState<number>(0);
+  const [myRatings, setMyRatings] = useState<Record<RatingAxisKey, number>>({
+    overall: 0,
+    spiciness: 0,
+    sweetness: 0,
+    saltiness: 0,
+    richness: 0,
+  });
   const [ratingSubmitting, setRatingSubmitting] = useState(false);
 
   if (authLoading || !isAuthenticated) {
@@ -68,15 +74,12 @@ function RecipeViewInner() {
 
   const isAuthor = user?.sub === recipe.authorUserId;
 
-  const handleRate = async (axis: 'overall' | 'spiciness', n: number) => {
-    if (axis === 'overall') setMyRating(n);
-    else setMySpiciness(n);
+  const handleRate = async (axisKey: RatingAxisKey, n: number) => {
+    setMyRatings((prev) => ({ ...prev, [axisKey]: n }));
     setRatingSubmitting(true);
+    const axisCfg = RATING_AXES.find((a) => a.key === axisKey)!;
     try {
-      await recipesApi.rate(
-        recipe.recipeId,
-        axis === 'overall' ? { rating: n } : { spiciness: n },
-      );
+      await recipesApi.rate(recipe.recipeId, { [axisCfg.bodyKey]: n } as RateAxes);
       refresh();
     } finally {
       setRatingSubmitting(false);
@@ -256,44 +259,34 @@ function RecipeViewInner() {
           )}
 
           <div className="pt-2 border-t border-zinc-800 space-y-3">
-            <div className="flex items-center justify-between gap-3">
-              <div>
-                <div className="text-xs uppercase tracking-wider text-zinc-400 font-semibold">
-                  Overall
+            {RATING_AXES.map((axis) => {
+              const avg = (recipe as unknown as Record<string, number | null>)[axis.avgKey];
+              const count = (recipe as unknown as Record<string, number>)[axis.countKey] ?? 0;
+              const my = myRatings[axis.key];
+              return (
+                <div key={axis.key} className="flex items-center justify-between gap-3">
+                  <div>
+                    <div className="text-xs uppercase tracking-wider text-zinc-400 font-semibold">
+                      {axis.label}
+                    </div>
+                    {count > 0 && avg != null ? (
+                      <p className="text-[11px] text-zinc-500 mt-0.5">
+                        avg {avg.toFixed(1)} · {count} {count === 1 ? 'rating' : 'ratings'}
+                      </p>
+                    ) : (
+                      <p className="text-[11px] text-zinc-500 mt-0.5">no ratings yet</p>
+                    )}
+                  </div>
+                  <IconRating
+                    value={my}
+                    onChange={(n) => void handleRate(axis.key, n)}
+                    icon={axis.icon}
+                    size="md"
+                    label={`Rate ${axis.label.toLowerCase()}`}
+                  />
                 </div>
-                {recipe.ratingCount > 0 && recipe.avgRating != null && (
-                  <p className="text-[11px] text-zinc-500 mt-0.5">
-                    avg {recipe.avgRating.toFixed(1)} · {recipe.ratingCount} {recipe.ratingCount === 1 ? 'rating' : 'ratings'}
-                  </p>
-                )}
-              </div>
-              <RatingStars
-                value={myRating}
-                onChange={(n) => void handleRate('overall', n)}
-                size="md"
-                label="Rate this recipe"
-              />
-            </div>
-            <div className="flex items-center justify-between gap-3">
-              <div>
-                <div className="text-xs uppercase tracking-wider text-zinc-400 font-semibold">
-                  Spiciness
-                </div>
-                {recipe.spicinessCount > 0 && recipe.spicinessAvg != null ? (
-                  <p className="text-[11px] text-zinc-500 mt-0.5">
-                    avg {recipe.spicinessAvg.toFixed(1)} · {recipe.spicinessCount} {recipe.spicinessCount === 1 ? 'rating' : 'ratings'}
-                  </p>
-                ) : (
-                  <p className="text-[11px] text-zinc-500 mt-0.5">no heat ratings yet</p>
-                )}
-              </div>
-              <RatingStars
-                value={mySpiciness}
-                onChange={(n) => void handleRate('spiciness', n)}
-                size="md"
-                label="Rate spiciness"
-              />
-            </div>
+              );
+            })}
             {ratingSubmitting && (
               <div className="text-[11px] text-zinc-500 italic">Saving…</div>
             )}

--- a/src/components/IconRating.tsx
+++ b/src/components/IconRating.tsx
@@ -1,0 +1,109 @@
+'use client';
+import type { CSSProperties } from 'react';
+
+interface Props {
+  value: number;
+  onChange?: (value: number) => void;
+  /** Icon to render — emoji string or character. */
+  icon: string;
+  /** Optional fallback for the unfilled state (defaults to a faded copy of `icon`). */
+  emptyIcon?: string;
+  size?: 'sm' | 'md' | 'lg';
+  readOnly?: boolean;
+  label?: string;
+}
+
+const SIZE = {
+  sm: { icon: 'text-base', cell: 'h-7 w-7' },
+  md: { icon: 'text-xl', cell: 'h-9 w-9' },
+  lg: { icon: 'text-2xl', cell: 'h-12 w-12' },
+};
+
+const FADED: CSSProperties = {
+  filter: 'grayscale(1) opacity(0.32)',
+};
+
+/**
+ * Generic 5-icon rating row. Same UX as a star rating, but the icon is
+ * configurable so we can use different glyphs per axis (star for overall,
+ * pepper for spiciness, honey pot for sweetness, etc).
+ *
+ * Filled icons render at full color/opacity; unfilled get a grayscale +
+ * low-opacity treatment that works for any emoji without per-axis art.
+ */
+export function IconRating({
+  value,
+  onChange,
+  icon,
+  emptyIcon,
+  size = 'md',
+  readOnly,
+  label,
+}: Props) {
+  const interactive = !readOnly && !!onChange;
+  const { icon: iconCls, cell } = SIZE[size];
+
+  return (
+    <div
+      role={interactive ? 'radiogroup' : undefined}
+      aria-label={label ?? 'Rating'}
+      className="inline-flex items-center gap-1"
+    >
+      {[1, 2, 3, 4, 5].map((n) => {
+        const active = n <= value;
+        const glyph = active ? icon : emptyIcon ?? icon;
+        const style = active ? undefined : FADED;
+        const inner = (
+          <span
+            aria-hidden="true"
+            className={`grid place-items-center rounded-md transition ${cell} ${iconCls}`}
+            style={style}
+          >
+            {glyph}
+          </span>
+        );
+        if (!interactive) {
+          return <span key={n}>{inner}</span>;
+        }
+        return (
+          <button
+            key={n}
+            type="button"
+            role="radio"
+            aria-checked={value === n}
+            aria-label={`${n} of 5`}
+            onClick={() => onChange?.(n)}
+            className="grid place-items-center rounded-md transition focus:outline-none focus:ring-2 focus:ring-coral-400/50"
+          >
+            {inner}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------- Per-axis presets ----------
+
+export type RatingAxisKey = 'overall' | 'spiciness' | 'sweetness' | 'saltiness' | 'richness';
+
+export interface RatingAxisConfig {
+  key: RatingAxisKey;
+  /** Camel-case body key the API expects. */
+  bodyKey: string;
+  /** Recipe-row aggregate keys. */
+  avgKey: string;
+  countKey: string;
+  /** Display label. */
+  label: string;
+  /** Glyph rendered by IconRating. */
+  icon: string;
+}
+
+export const RATING_AXES: RatingAxisConfig[] = [
+  { key: 'overall',   bodyKey: 'rating',    avgKey: 'avgRating',    countKey: 'ratingCount',    label: 'Overall',   icon: '⭐' },
+  { key: 'spiciness', bodyKey: 'spiciness', avgKey: 'spicinessAvg', countKey: 'spicinessCount', label: 'Spice',     icon: '🌶️' },
+  { key: 'sweetness', bodyKey: 'sweetness', avgKey: 'sweetnessAvg', countKey: 'sweetnessCount', label: 'Sweetness', icon: '🍯' },
+  { key: 'saltiness', bodyKey: 'saltiness', avgKey: 'saltinessAvg', countKey: 'saltinessCount', label: 'Saltiness', icon: '🧂' },
+  { key: 'richness',  bodyKey: 'richness',  avgKey: 'richnessAvg',  countKey: 'richnessCount',  label: 'Richness',  icon: '🧈' },
+];

--- a/src/components/RatingStars.tsx
+++ b/src/components/RatingStars.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { IconRating } from './IconRating';
 
 interface Props {
   value: number;
@@ -8,57 +9,10 @@ interface Props {
   label?: string;
 }
 
-const SIZE = {
-  sm: 'text-base h-7 w-7',
-  md: 'text-xl h-9 w-9',
-  lg: 'text-2xl h-12 w-12',
-};
-
-export function RatingStars({ value, onChange, size = 'md', readOnly, label }: Props) {
-  const interactive = !readOnly && !!onChange;
-  const cls = SIZE[size];
-
-  return (
-    <div
-      role={interactive ? 'radiogroup' : undefined}
-      aria-label={label ?? 'Rating'}
-      className="inline-flex items-center gap-1"
-    >
-      {[1, 2, 3, 4, 5].map((n) => {
-        const active = n <= value;
-        const Star = (
-          <span
-            aria-hidden="true"
-            className={`grid place-items-center rounded-md transition ${cls} ${
-              active
-                ? 'text-coral-300'
-                : 'text-zinc-700'
-            }`}
-          >
-            ★
-          </span>
-        );
-        if (!interactive) {
-          return <span key={n}>{Star}</span>;
-        }
-        return (
-          <button
-            key={n}
-            type="button"
-            role="radio"
-            aria-checked={value === n}
-            aria-label={`${n} of 5`}
-            onClick={() => onChange?.(n)}
-            className={`grid place-items-center rounded-md transition focus:outline-none focus:ring-2 focus:ring-coral-400/50 ${cls} ${
-              active
-                ? 'text-coral-300 hover:text-coral-200'
-                : 'text-zinc-700 hover:text-zinc-500'
-            }`}
-          >
-            ★
-          </button>
-        );
-      })}
-    </div>
-  );
+/**
+ * Star-shaped rating — thin wrapper around IconRating for callers that
+ * don't care about the new themed-axis system (CookForm, /cooks/view).
+ */
+export function RatingStars(props: Props) {
+  return <IconRating {...props} icon="⭐" />;
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -69,10 +69,27 @@ export interface RateRecipeResult {
   userId: string;
   rating: number | null;
   spiciness: number | null;
+  sweetness: number | null;
+  saltiness: number | null;
+  richness: number | null;
   avgRating: number | null;
   ratingCount: number;
   spicinessAvg: number | null;
   spicinessCount: number;
+  sweetnessAvg: number | null;
+  sweetnessCount: number;
+  saltinessAvg: number | null;
+  saltinessCount: number;
+  richnessAvg: number | null;
+  richnessCount: number;
+}
+
+export interface RateAxes {
+  rating?: number;
+  spiciness?: number;
+  sweetness?: number;
+  saltiness?: number;
+  richness?: number;
 }
 
 export interface ListPublicFilters {
@@ -136,10 +153,7 @@ export const recipesApi = {
     apiPost<Recipe>('/recipes/edit', { recipeId, ...fields }),
   delete: (recipeId: string): Promise<void> =>
     apiPost<void>('/recipes/delete', { recipeId }),
-  rate: (
-    recipeId: string,
-    axes: { rating?: number; spiciness?: number },
-  ): Promise<RateRecipeResult> =>
+  rate: (recipeId: string, axes: RateAxes): Promise<RateRecipeResult> =>
     apiPost<RateRecipeResult>('/recipes/rate', { recipeId, ...axes }),
   like: (recipeId: string): Promise<{ recipeId: string; likeCount: number; likedByMe: boolean }> =>
     apiPost('/recipes/like', { recipeId }),

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -250,7 +250,7 @@ export function useRecipe(recipeId: string | null) {
     isLoading,
     error,
     refresh: () => mutateOne(),
-    rate: async (axes: { rating?: number; spiciness?: number }) => {
+    rate: async (axes: import('./api').RateAxes) => {
       if (!recipeId) return;
       await recipesApi.rate(recipeId, axes);
       mutateOne();

--- a/src/types.ts
+++ b/src/types.ts
@@ -211,6 +211,12 @@ export interface Recipe {
   ratingCount: number;
   spicinessAvg: number | null;
   spicinessCount: number;
+  sweetnessAvg: number | null;
+  sweetnessCount: number;
+  saltinessAvg: number | null;
+  saltinessCount: number;
+  richnessAvg: number | null;
+  richnessCount: number;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
Pairs with [xomappetit-backend#24](https://github.com/Xomware/xomappetit-backend/pull/24).

Replaces the inline RatingStars duplication in /recipes/view with a single IconRating component and a RATING_AXES table. /recipes/view now renders all 5 axes (Overall ⭐ / Spiciness 🌶️ / Sweetness 🍯 / Saltiness 🧂 / Richness 🧈), each with its own glyph; unfilled cells get a grayscale + low-opacity treatment that works for any future axis.

Adding a 6th axis takes one entry in RATING_AXES + one entry in the backend AXES table — no /recipes/view changes needed.

## Test plan
- [ ] Tap each axis → it saves; the recipe-row aggregates show in the 'avg X · N ratings' subline
- [ ] CookForm + /cooks/view still work (RatingStars wrapper preserved)
- [ ] Filled icons render at full color, unfilled icons appear faded/gray