### PR TITLE
feat(cooks): wizard form + people picker for chefs/diners

### DIFF
--- a/src/app/cooks/new/page.tsx
+++ b/src/app/cooks/new/page.tsx
@@ -36,6 +36,8 @@ function NewCookInner() {
     const cook = await logCook({
       recipeId,
       cookedAt: values.cookedAt,
+      chefs: values.chefs,
+      diners: values.diners,
       notes: values.notes || undefined,
       photoUrl: values.photoUrl,
       rating: values.rating,

--- a/src/app/cooks/view/page.tsx
+++ b/src/app/cooks/view/page.tsx
@@ -91,12 +91,15 @@ function CookViewInner() {
             <CookForm
               initial={{
                 cookedAt: cook.cookedAt,
+                chefs: cook.chefs,
+                diners: cook.diners,
                 notes: cook.notes,
                 photoUrl: cook.photoUrl,
                 rating: cook.rating,
               }}
               showCookedAt
               cookedAtImmutable
+              participantsImmutable
               submitLabel="Save changes"
               onSubmit={handleEditSubmit}
             />

--- a/src/components/CookForm.tsx
+++ b/src/components/CookForm.tsx
@@ -1,6 +1,10 @@
 'use client';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { RatingStars } from './RatingStars';
+import PeoplePickerModal from './PeoplePickerModal';
+import { useUsersById } from '@/lib/use-users-by-id';
+import { useAuth } from '@/lib/auth-context';
+import { PublicUserProfile } from '@/lib/users';
 
 const inputCls =
   'w-full bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-coral-400 focus:border-transparent';
@@ -9,6 +13,8 @@ const labelCls =
 
 export interface CookFormValues {
   cookedAt: string;
+  chefs: string[];
+  diners: string[];
   notes: string;
   photoUrl: string | null;
   rating: number | null;
@@ -19,8 +25,18 @@ interface Props {
   submitLabel: string;
   showCookedAt: boolean;
   cookedAtImmutable?: boolean;
+  /** When true, hides the chefs/diners pickers (used by /cooks/view edit). */
+  participantsImmutable?: boolean;
   onSubmit: (values: CookFormValues) => Promise<void>;
 }
+
+const STEP_ORDER = ['who', 'details', 'rating'] as const;
+type StepId = (typeof STEP_ORDER)[number];
+const STEP_LABELS: Record<StepId, string> = {
+  who: 'When & who',
+  details: 'Photo & notes',
+  rating: 'Rating',
+};
 
 function nowLocalIso(): string {
   const d = new Date();
@@ -33,24 +49,63 @@ export function CookForm({
   submitLabel,
   showCookedAt,
   cookedAtImmutable,
+  participantsImmutable,
   onSubmit,
 }: Props) {
+  const { user } = useAuth();
+  const callerId = user?.sub ?? '';
+
   const [cookedAt, setCookedAt] = useState(
     initial?.cookedAt ? initial.cookedAt.slice(0, 16) : nowLocalIso(),
   );
+  // Caller is always a chef by default — backend enforces this anyway, but
+  // showing them here makes the UX legible.
+  const [chefs, setChefs] = useState<string[]>(() => {
+    const seed = initial?.chefs ?? [];
+    if (callerId && !seed.includes(callerId)) return [callerId, ...seed];
+    return seed;
+  });
+  const [diners, setDiners] = useState<string[]>(initial?.diners ?? []);
   const [notes, setNotes] = useState(initial?.notes ?? '');
   const [photoUrl, setPhotoUrl] = useState(initial?.photoUrl ?? '');
   const [rating, setRating] = useState<number>(initial?.rating ?? 0);
+
+  const [stepId, setStepId] = useState<StepId>(participantsImmutable ? 'details' : 'who');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const [chefsModalOpen, setChefsModalOpen] = useState(false);
+  const [dinersModalOpen, setDinersModalOpen] = useState(false);
+
+  const stepIdx = STEP_ORDER.indexOf(stepId);
+  const isLastStep = stepIdx === STEP_ORDER.length - 1;
+
+  const goNext = () => {
+    if (isLastStep) {
+      void handleSubmit();
+      return;
+    }
+    setStepId(STEP_ORDER[stepIdx + 1]);
+    if (typeof window !== 'undefined') window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const goBack = () => {
+    if (stepIdx === 0) return;
+    setStepId(STEP_ORDER[stepIdx - 1]);
+    if (typeof window !== 'undefined') window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  const handleSubmit = async () => {
     setSubmitting(true);
     setError(null);
     try {
+      // Diners can't also be chefs — backend filters this but we mirror it
+      // here so the UI never sends an obviously bad payload.
+      const cleanedDiners = diners.filter((d) => !chefs.includes(d));
       await onSubmit({
         cookedAt: new Date(cookedAt).toISOString(),
+        chefs,
+        diners: cleanedDiners,
         notes: notes.trim(),
         photoUrl: photoUrl.trim() || null,
         rating: rating > 0 ? rating : null,
@@ -63,7 +118,167 @@ export function CookForm({
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-5">
+    <div className="space-y-6">
+      <ProgressBar
+        current={stepIdx}
+        total={STEP_ORDER.length}
+        label={STEP_LABELS[stepId]}
+      />
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          goNext();
+        }}
+        className="space-y-5"
+      >
+        {stepId === 'who' && (
+          <WhoStep
+            showCookedAt={showCookedAt}
+            cookedAt={cookedAt}
+            setCookedAt={setCookedAt}
+            cookedAtImmutable={cookedAtImmutable}
+            chefs={chefs}
+            diners={diners}
+            callerId={callerId}
+            removeChef={(id) =>
+              setChefs((prev) => (id === callerId ? prev : prev.filter((x) => x !== id)))
+            }
+            removeDiner={(id) => setDiners((prev) => prev.filter((x) => x !== id))}
+            openChefs={() => setChefsModalOpen(true)}
+            openDiners={() => setDinersModalOpen(true)}
+          />
+        )}
+
+        {stepId === 'details' && (
+          <DetailsStep
+            notes={notes}
+            setNotes={setNotes}
+            photoUrl={photoUrl}
+            setPhotoUrl={setPhotoUrl}
+          />
+        )}
+
+        {stepId === 'rating' && (
+          <RatingStep rating={rating} setRating={setRating} />
+        )}
+
+        {error && (
+          <div
+            role="alert"
+            className="text-xs text-coral-300 bg-coral-900/30 border border-coral-800 rounded-md px-3 py-2"
+          >
+            {error}
+          </div>
+        )}
+
+        <div className="sticky bottom-0 -mx-6 px-6 py-3 bg-zinc-950/95 backdrop-blur border-t border-zinc-800 flex items-center gap-3">
+          <button
+            type="button"
+            onClick={goBack}
+            disabled={stepIdx === 0 || submitting}
+            className="bg-zinc-900 hover:bg-zinc-800 border border-zinc-800 text-zinc-300 disabled:opacity-30 disabled:cursor-not-allowed px-4 py-2.5 rounded-lg text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-coral-400/40"
+          >
+            Back
+          </button>
+          <button
+            type="submit"
+            disabled={submitting}
+            className="flex-1 bg-gradient-to-r from-coral-500 to-coral-400 hover:from-coral-400 hover:to-coral-300 disabled:opacity-40 disabled:cursor-not-allowed text-white font-bold uppercase tracking-wider py-2.5 px-4 rounded-lg transition shadow-lg shadow-coral-500/20 focus:outline-none focus:ring-2 focus:ring-coral-400/50"
+          >
+            {submitting ? 'Saving…' : isLastStep ? submitLabel : 'Continue'}
+          </button>
+        </div>
+      </form>
+
+      <PeoplePickerModal
+        open={chefsModalOpen}
+        title="Who cooked"
+        selected={chefs}
+        excludeUserIds={diners}
+        onClose={() => setChefsModalOpen(false)}
+        onChange={(next) => {
+          // Caller stays in chefs by default. Allow other people to come and go.
+          if (callerId && !next.includes(callerId)) {
+            setChefs([callerId, ...next.filter((x) => x !== callerId)]);
+          } else {
+            setChefs(next);
+          }
+        }}
+      />
+      <PeoplePickerModal
+        open={dinersModalOpen}
+        title="Who ate"
+        selected={diners}
+        excludeUserIds={chefs}
+        onClose={() => setDinersModalOpen(false)}
+        onChange={setDiners}
+      />
+    </div>
+  );
+}
+
+// ---------- Wizard chrome ----------
+
+function ProgressBar({ current, total, label }: { current: number; total: number; label: string }) {
+  return (
+    <div>
+      <div className="flex items-center gap-2">
+        {Array.from({ length: total }, (_, i) => (
+          <span
+            key={i}
+            className={`h-1.5 flex-1 rounded-full transition ${
+              i <= current ? 'bg-coral-400' : 'bg-zinc-800'
+            }`}
+          />
+        ))}
+      </div>
+      <div className="mt-2 flex items-baseline justify-between">
+        <h3 className="font-display text-base font-black uppercase tracking-wide">{label}</h3>
+        <span className="text-[11px] text-zinc-500">
+          Step {current + 1} of {total}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ---------- Step 1: Who & when ----------
+
+function WhoStep({
+  showCookedAt,
+  cookedAt,
+  setCookedAt,
+  cookedAtImmutable,
+  chefs,
+  diners,
+  callerId,
+  removeChef,
+  removeDiner,
+  openChefs,
+  openDiners,
+}: {
+  showCookedAt: boolean;
+  cookedAt: string;
+  setCookedAt: (v: string) => void;
+  cookedAtImmutable?: boolean;
+  chefs: string[];
+  diners: string[];
+  callerId: string;
+  removeChef: (id: string) => void;
+  removeDiner: (id: string) => void;
+  openChefs: () => void;
+  openDiners: () => void;
+}) {
+  // Resolve names for the chip rows.
+  const ids = useMemo(
+    () => Array.from(new Set([...chefs, ...diners])),
+    [chefs, diners],
+  );
+  const { map: profiles } = useUsersById(ids);
+
+  return (
+    <div className="space-y-5">
       {showCookedAt && (
         <div>
           <label className={labelCls}>Cooked at</label>
@@ -82,62 +297,162 @@ export function CookForm({
         </div>
       )}
 
+      <PeopleSection
+        label="Who cooked"
+        userIds={chefs}
+        callerId={callerId}
+        profiles={profiles}
+        onPick={openChefs}
+        onRemove={removeChef}
+        emptyHint="You'll be added automatically — pick others if it was a team effort."
+      />
+      <PeopleSection
+        label="Who ate"
+        userIds={diners}
+        callerId={callerId}
+        profiles={profiles}
+        onPick={openDiners}
+        onRemove={removeDiner}
+        emptyHint="Optional — pick the people you served."
+      />
+    </div>
+  );
+}
+
+function PeopleSection({
+  label,
+  userIds,
+  callerId,
+  profiles,
+  onPick,
+  onRemove,
+  emptyHint,
+}: {
+  label: string;
+  userIds: string[];
+  callerId: string;
+  profiles: Map<string, PublicUserProfile>;
+  onPick: () => void;
+  onRemove: (id: string) => void;
+  emptyHint: string;
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className={labelCls + ' mb-0'}>{label}</span>
+        <button
+          type="button"
+          onClick={onPick}
+          className="text-xs font-semibold uppercase tracking-wider text-coral-400 hover:text-coral-300"
+        >
+          + Pick
+        </button>
+      </div>
+      {userIds.length === 0 ? (
+        <p className="text-xs text-zinc-500 italic">{emptyHint}</p>
+      ) : (
+        <div className="flex flex-wrap gap-1.5">
+          {userIds.map((id) => {
+            const p = profiles.get(id);
+            const handle = p?.preferredUsername;
+            const name = p?.displayName?.trim();
+            const isMe = id === callerId;
+            const display = isMe
+              ? 'You'
+              : name || (handle ? `@${handle}` : `${id.slice(0, 6)}…`);
+            return (
+              <button
+                key={id}
+                type="button"
+                onClick={() => (isMe ? undefined : onRemove(id))}
+                disabled={isMe}
+                className={`text-xs px-2.5 py-1 rounded-full border transition ${
+                  isMe
+                    ? 'bg-coral-500/30 border-coral-500/60 text-coral-100 cursor-default'
+                    : 'bg-coral-500/20 border-coral-500/50 text-coral-200 hover:bg-coral-500/30'
+                }`}
+                aria-label={isMe ? 'You (always included)' : `Remove ${display}`}
+              >
+                {display}
+                {!isMe && <span className="ml-1 text-coral-300/70">×</span>}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------- Step 2: Photo & notes ----------
+
+function DetailsStep({
+  notes,
+  setNotes,
+  photoUrl,
+  setPhotoUrl,
+}: {
+  notes: string;
+  setNotes: (v: string) => void;
+  photoUrl: string;
+  setPhotoUrl: (v: string) => void;
+}) {
+  return (
+    <div className="space-y-5">
       <div>
         <label className={labelCls}>Notes</label>
         <textarea
-          className={inputCls + ' min-h-[80px] resize-y'}
+          className={inputCls + ' min-h-[100px] resize-y'}
           value={notes}
           onChange={(e) => setNotes(e.target.value)}
           placeholder="What worked? What flopped? Subs you made?"
         />
       </div>
-
       <div>
         <label className={labelCls}>Photo URL</label>
         <input
           type="url"
+          inputMode="url"
           className={inputCls}
           value={photoUrl}
           onChange={(e) => setPhotoUrl(e.target.value)}
           placeholder="https://…"
         />
-      </div>
-
-      <div>
-        <span className={labelCls}>Your rating</span>
-        <div className="flex items-center gap-3">
-          <RatingStars value={rating} onChange={setRating} size="md" label="Recipe rating" />
-          {rating > 0 && (
-            <button
-              type="button"
-              onClick={() => setRating(0)}
-              className="text-xs text-zinc-500 hover:text-coral-300 transition"
-            >
-              clear
-            </button>
-          )}
-        </div>
-        <p className="mt-1.5 text-[11px] text-zinc-500">
-          Optional. Also gets saved as your recipe rating.
+        <p className="mt-1 text-[11px] text-zinc-500">
+          Optional — paste any image URL. Inline upload is coming.
         </p>
       </div>
+    </div>
+  );
+}
 
-      {error && (
-        <div
-          role="alert"
-          className="text-xs text-coral-300 bg-coral-900/30 border border-coral-800 rounded-md px-3 py-2"
-        >
-          {error}
-        </div>
-      )}
+// ---------- Step 3: Rating ----------
 
-      <button
-        type="submit"
-        disabled={submitting}
-        className="w-full bg-gradient-to-r from-coral-500 to-coral-400 hover:from-coral-400 hover:to-coral-300 disabled:opacity-40 disabled:cursor-not-allowed text-white font-bold uppercase tracking-wider py-2.5 px-4 rounded-lg transition shadow-lg shadow-coral-500/20 focus:outline-none focus:ring-2 focus:ring-coral-400/50"
-      >
-        {submitting ? 'Saving…' : submitLabel}
-      </button>
-    </form>
+function RatingStep({
+  rating,
+  setRating,
+}: {
+  rating: number;
+  setRating: (n: number) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <span className={labelCls}>How was this cook?</span>
+      <div className="flex items-center gap-3">
+        <RatingStars value={rating} onChange={setRating} size="lg" label="Cook rating" />
+        {rating > 0 && (
+          <button
+            type="button"
+            onClick={() => setRating(0)}
+            className="text-xs text-zinc-500 hover:text-coral-300 transition"
+          >
+            clear
+          </button>
+        )}
+      </div>
+      <p className="text-[11px] text-zinc-500">
+        Optional — rate this specific cook session. Recipe ratings live on the recipe page.
+      </p>
+    </div>
   );
 }

--- a/src/components/PeoplePickerModal.tsx
+++ b/src/components/PeoplePickerModal.tsx
@@ -1,0 +1,325 @@
+'use client';
+import { useEffect, useMemo, useState } from 'react';
+import { useFriends } from '@/lib/hooks';
+import { useUsersById } from '@/lib/use-users-by-id';
+import { usersSearchApi } from '@/lib/api';
+import { PublicUserProfile } from '@/lib/users';
+
+interface Props {
+  open: boolean;
+  title: string;
+  /** User IDs already selected. */
+  selected: string[];
+  /** User IDs to exclude entirely (e.g. chefs hidden from the diners picker). */
+  excludeUserIds?: string[];
+  onClose: () => void;
+  onChange: (next: string[]) => void;
+}
+
+/**
+ * Multi-select people picker. Shows friends first, then a network search by
+ * handle prefix when the query has 2+ characters. Selected people stay pinned
+ * at the top so removing one is one tap.
+ *
+ * Returns user IDs (Cognito sub) — the cook-log API takes these directly.
+ */
+export default function PeoplePickerModal({
+  open,
+  title,
+  selected,
+  excludeUserIds = [],
+  onClose,
+  onChange,
+}: Props) {
+  const [query, setQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<PublicUserProfile[]>([]);
+  const [searching, setSearching] = useState(false);
+
+  const { friends } = useFriends();
+  // Resolve display profiles for friends + selected (selected may include
+  // non-friends if the picker was used with handle search).
+  const idsToResolve = useMemo(
+    () => Array.from(new Set([...friends.map((f) => f.userId), ...selected])),
+    [friends, selected],
+  );
+  const { map: profiles } = useUsersById(idsToResolve);
+
+  const exclude = useMemo(() => new Set(excludeUserIds), [excludeUserIds]);
+  const selectedSet = useMemo(() => new Set(selected), [selected]);
+
+  // Network search debounced lightly — we don't need a fancy debounce since
+  // the results lazily render and Cognito search is ~200ms.
+  useEffect(() => {
+    if (!open) return;
+    const q = query.trim();
+    if (q.length < 2) {
+      setSearchResults([]);
+      return;
+    }
+    let cancelled = false;
+    setSearching(true);
+    const t = setTimeout(() => {
+      usersSearchApi
+        .byHandlePrefix(q, 12)
+        .then((res) => {
+          if (cancelled) return;
+          setSearchResults(res.users);
+        })
+        .catch(() => {
+          if (!cancelled) setSearchResults([]);
+        })
+        .finally(() => {
+          if (!cancelled) setSearching(false);
+        });
+    }, 220);
+    return () => {
+      cancelled = true;
+      clearTimeout(t);
+    };
+  }, [open, query]);
+
+  // Esc + body scroll lock
+  useEffect(() => {
+    if (!open) return;
+    setQuery('');
+    setSearchResults([]);
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    const prev = document.documentElement.style.overflow;
+    document.documentElement.style.overflow = 'hidden';
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      document.documentElement.style.overflow = prev;
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const toggle = (userId: string) => {
+    if (selectedSet.has(userId)) {
+      onChange(selected.filter((x) => x !== userId));
+    } else {
+      onChange([...selected, userId]);
+    }
+  };
+
+  // Build the rendered rows. Pinned selected first, then friends, then search.
+  const friendIds = friends.map((f) => f.userId);
+  const visibleFriendIds = friendIds.filter((id) => {
+    if (exclude.has(id)) return false;
+    if (!query.trim()) return true;
+    const p = profiles.get(id);
+    const haystack = `${p?.displayName ?? ''} ${p?.preferredUsername ?? ''}`.toLowerCase();
+    return haystack.includes(query.trim().toLowerCase());
+  });
+
+  const seenInLists = new Set<string>([...selected, ...visibleFriendIds]);
+  const searchOnlyResults = searchResults.filter(
+    (u) => !seenInLists.has(u.userId) && !exclude.has(u.userId),
+  );
+
+  const selectedRows: { userId: string; profile: PublicUserProfile | undefined }[] = selected.map(
+    (id) => ({ userId: id, profile: profiles.get(id) }),
+  );
+  const friendRows = visibleFriendIds
+    .filter((id) => !selectedSet.has(id))
+    .map((id) => ({ userId: id, profile: profiles.get(id) }));
+  const searchRows = searchOnlyResults.map((u) => ({ userId: u.userId, profile: u }));
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/60 backdrop-blur-sm p-0 sm:p-4"
+    >
+      <button
+        type="button"
+        aria-label="Close"
+        onClick={onClose}
+        className="absolute inset-0 -z-10"
+      />
+      <div className="bg-zinc-950 w-full sm:max-w-md rounded-t-2xl sm:rounded-2xl border border-zinc-800 shadow-2xl flex flex-col max-h-[85vh] overflow-hidden">
+        <header className="flex items-center justify-between gap-3 p-4 border-b border-zinc-800">
+          <div className="min-w-0">
+            <h2 className="font-display text-lg font-black uppercase tracking-wide truncate">
+              {title}
+            </h2>
+            <p className="text-[11px] text-zinc-500 mt-0.5">
+              {selected.length} selected
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="h-9 w-9 grid place-items-center rounded-md text-zinc-400 hover:text-white hover:bg-zinc-800 transition"
+          >
+            <svg viewBox="0 0 24 24" className="h-5 w-5" aria-hidden="true">
+              <path
+                fill="currentColor"
+                d="M6.4 4.99 12 10.6l5.6-5.61 1.41 1.41L13.41 12l5.6 5.6-1.41 1.41L12 13.41l-5.6 5.6-1.41-1.41L10.59 12l-5.6-5.6L6.4 4.99z"
+              />
+            </svg>
+          </button>
+        </header>
+
+        <div className="p-3 border-b border-zinc-800">
+          <input
+            type="search"
+            autoFocus
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search friends or by @handle…"
+            className="w-full bg-zinc-900 border border-zinc-700 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-coral-400 focus:border-transparent"
+          />
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-2 space-y-3">
+          {selectedRows.length > 0 && (
+            <Section label="Selected">
+              {selectedRows.map(({ userId, profile }) => (
+                <PersonRow
+                  key={userId}
+                  userId={userId}
+                  profile={profile}
+                  selected
+                  onClick={() => toggle(userId)}
+                />
+              ))}
+            </Section>
+          )}
+
+          {friendRows.length > 0 && (
+            <Section label={query.trim() ? 'Matching friends' : 'Friends'}>
+              {friendRows.map(({ userId, profile }) => (
+                <PersonRow
+                  key={userId}
+                  userId={userId}
+                  profile={profile}
+                  selected={false}
+                  onClick={() => toggle(userId)}
+                />
+              ))}
+            </Section>
+          )}
+
+          {searching && (
+            <p className="text-xs text-zinc-500 italic px-2 py-1">Searching…</p>
+          )}
+
+          {!searching && searchRows.length > 0 && (
+            <Section label="Other people">
+              {searchRows.map(({ userId, profile }) => (
+                <PersonRow
+                  key={userId}
+                  userId={userId}
+                  profile={profile}
+                  selected={false}
+                  onClick={() => toggle(userId)}
+                />
+              ))}
+            </Section>
+          )}
+
+          {!searching &&
+            selectedRows.length === 0 &&
+            friendRows.length === 0 &&
+            searchRows.length === 0 && (
+              <p className="text-sm text-zinc-500 italic text-center py-8">
+                {query.trim()
+                  ? 'No matches. Try a different handle.'
+                  : 'No friends yet. Add some in /friends or search by handle above.'}
+              </p>
+            )}
+        </div>
+
+        <footer className="border-t border-zinc-800 p-3 flex gap-2">
+          <button
+            type="button"
+            onClick={() => onChange([])}
+            disabled={selected.length === 0}
+            className="bg-zinc-900 hover:bg-zinc-800 border border-zinc-800 text-zinc-300 disabled:opacity-40 px-4 py-2 rounded-lg text-sm font-semibold transition"
+          >
+            Clear
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex-1 bg-gradient-to-r from-coral-500 to-coral-400 hover:from-coral-400 hover:to-coral-300 text-white py-2 rounded-lg text-sm font-bold uppercase tracking-wide transition shadow-lg shadow-coral-500/20 focus:outline-none focus:ring-2 focus:ring-coral-400/50"
+          >
+            Done
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+function Section({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <div className="text-[10px] uppercase tracking-wider text-zinc-500 px-2 mb-1">
+        {label}
+      </div>
+      <div className="space-y-1">{children}</div>
+    </div>
+  );
+}
+
+function PersonRow({
+  userId,
+  profile,
+  selected,
+  onClick,
+}: {
+  userId: string;
+  profile: PublicUserProfile | undefined;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  const handle = profile?.preferredUsername;
+  const name = profile?.displayName?.trim();
+  const avatarUrl = profile?.avatarUrl;
+  const headline = name || (handle ? `@${handle}` : `${userId.slice(0, 8)}…`);
+  const subline = name && handle ? `@${handle}` : null;
+  const initial = (name || handle || '?').charAt(0).toUpperCase();
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg transition ${
+        selected
+          ? 'bg-coral-500/15 hover:bg-coral-500/20'
+          : 'bg-zinc-900/50 hover:bg-zinc-900'
+      }`}
+    >
+      <span className="h-9 w-9 rounded-full overflow-hidden bg-zinc-800 grid place-items-center shrink-0">
+        {avatarUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={avatarUrl} alt="" className="h-full w-full object-cover" />
+        ) : (
+          <span className="h-full w-full grid place-items-center bg-gradient-to-br from-coral-500 to-flame-500 text-white text-sm font-black uppercase">
+            {initial}
+          </span>
+        )}
+      </span>
+      <span className="min-w-0 flex-1 text-left">
+        <span className={`block text-sm font-semibold truncate ${selected ? 'text-coral-200' : 'text-zinc-100'}`}>
+          {headline}
+        </span>
+        {subline && (
+          <span className="block text-[11px] text-zinc-500 truncate">{subline}</span>
+        )}
+      </span>
+      {selected && (
+        <span className="text-coral-300 text-base shrink-0" aria-label="Selected">
+          ✓
+        </span>
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
Closes the loop on the form-redesign feedback. The cook-log form now matches the recipe wizard pattern.

### CookForm wizard
3 steps:
1. **When & who** — cookedAt input + Who-cooked + Who-ate pickers
2. **Photo & notes**
3. **Rating** (single-axis stars; recipe-level multi-axis ratings live on /recipes/view)

### PeoplePickerModal
Multi-select people picker:
- Friends list shown by default (resolved via useFriends → useUsersById for names + avatars)
- Search debounces 220ms, then hits \`/users/search\` for non-friends
- Selected people pin to the top so removing one is one tap
- Body scroll locked, Esc closes, click backdrop closes

### Wiring
The \`cooks-log\` lambda already accepted \`chefs\` + \`diners\` — this just exposes the UI:
- /cooks/new passes both through to logCook
- The caller is auto-pinned as a chef (mirrors the backend default) and can't be removed in the UI
- Diners can't include any chef (UI + backend both filter)
- /cooks/view edit mode hides the people pickers (participants are immutable per the cook schema; new \`participantsImmutable\` prop on CookForm)

## Test plan
- [ ] /cooks/new from a recipe page: step 1 shows you pinned as a chef + a 'Pick' button on each row
- [ ] Tap 'Pick' on Who-cooked → modal opens with your friends; tap one → selected, pinned at top; type a handle → cross-app results appear; tap Done returns
- [ ] Diners modal excludes anyone already in chefs and vice versa
- [ ] Save → /cooks/view shows the chef + diner pills with real names (existing PeopleList from cooks-view)
- [ ] /cooks/view edit mode: only the When/photo/notes/rating fields show — no chefs/diners pickers