### PR TITLE
fix(form): kinder number inputs + warn on unused ingredients

### DIFF
--- a/src/components/IngredientsEditor.tsx
+++ b/src/components/IngredientsEditor.tsx
@@ -9,6 +9,7 @@ import {
   UNITLESS_UNITS,
 } from '@/types';
 import { ingredientSuggestions } from '@/lib/common-ingredients';
+import NumberInput from './NumberInput';
 
 interface Props {
   ingredients: Ingredient[];
@@ -70,20 +71,14 @@ export default function IngredientsEditor({ ingredients, onChange }: Props) {
             key={i}
             className="grid grid-cols-[70px_90px_1fr_auto] sm:grid-cols-[80px_100px_1fr_auto] gap-2 items-center"
           >
-            <input
-              type="number"
-              inputMode="decimal"
+            <NumberInput
+              decimal
               min={0}
-              step="0.25"
               placeholder="qty"
               disabled={unitless}
               className={inputCls + (unitless ? ' opacity-40' : '')}
-              value={ing.amount ?? ''}
-              onChange={(e) =>
-                update(i, {
-                  amount: e.target.value === '' ? null : Number(e.target.value),
-                })
-              }
+              value={ing.amount}
+              onChange={(amount) => update(i, { amount })}
             />
             <select
               className={inputCls}

--- a/src/components/NumberInput.tsx
+++ b/src/components/NumberInput.tsx
@@ -1,0 +1,79 @@
+'use client';
+import { useEffect, useState, FocusEvent, InputHTMLAttributes } from 'react';
+
+type Base = Omit<InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange' | 'type'>;
+
+interface Props extends Base {
+  value: number | null;
+  onChange: (next: number | null) => void;
+  /** Allow decimal points. Default false (integer-only). */
+  decimal?: boolean;
+  min?: number;
+  max?: number;
+}
+
+/**
+ * Number input that's actually pleasant on mobile.
+ *
+ * - Local string state so backspacing the existing value doesn't snap to 0
+ * - select-all on focus so tap-and-type replaces the field
+ * - inputMode=numeric / decimal so the right keyboard shows up
+ * - Commits to parent on blur (parses + clamps)
+ * - When parent value changes externally (e.g., auto-calc filled it),
+ *   the field syncs via useEffect
+ */
+export default function NumberInput({
+  value,
+  onChange,
+  decimal = false,
+  min,
+  max,
+  onBlur,
+  className,
+  ...rest
+}: Props) {
+  const [draft, setDraft] = useState(value === null || value === undefined ? '' : String(value));
+
+  useEffect(() => {
+    setDraft(value === null || value === undefined ? '' : String(value));
+  }, [value]);
+
+  const commit = (e: FocusEvent<HTMLInputElement>) => {
+    const trimmed = draft.trim();
+    if (trimmed === '') {
+      onChange(null);
+    } else {
+      const n = decimal ? parseFloat(trimmed) : parseInt(trimmed, 10);
+      if (!Number.isFinite(n)) {
+        // Bad input — revert to the last good parent value.
+        setDraft(value === null || value === undefined ? '' : String(value));
+      } else {
+        let clamped = n;
+        if (min !== undefined && clamped < min) clamped = min;
+        if (max !== undefined && clamped > max) clamped = max;
+        onChange(clamped);
+        setDraft(String(clamped));
+      }
+    }
+    onBlur?.(e);
+  };
+
+  const allowedRe = decimal ? /^\d*\.?\d*$/ : /^\d*$/;
+
+  return (
+    <input
+      type="text"
+      inputMode={decimal ? 'decimal' : 'numeric'}
+      pattern={decimal ? '[0-9]*[.]?[0-9]*' : '[0-9]*'}
+      value={draft}
+      onFocus={(e) => e.currentTarget.select()}
+      onChange={(e) => {
+        const v = e.currentTarget.value;
+        if (allowedRe.test(v)) setDraft(v);
+      }}
+      onBlur={commit}
+      className={className}
+      {...rest}
+    />
+  );
+}

--- a/src/components/RecipeForm.tsx
+++ b/src/components/RecipeForm.tsx
@@ -20,6 +20,7 @@ import IngredientsEditor from './IngredientsEditor';
 import InstructionsEditor from './InstructionsEditor';
 import ChipPickerModal, { ChipOption } from './ChipPickerModal';
 import IngredientPickerModal from './IngredientPickerModal';
+import NumberInput from './NumberInput';
 import { rememberIngredient } from '@/lib/common-ingredients';
 import { recipesApi, ComputeMacrosResult } from '@/lib/api';
 
@@ -399,23 +400,19 @@ function BasicsStep({
       <div className="grid grid-cols-2 gap-3">
         <div>
           <label className={labelCls}>Time (min)</label>
-          <input
-            type="number"
-            inputMode="numeric"
+          <NumberInput
             className={inputCls}
             value={timeMinutes}
-            onChange={(e) => setTimeMinutes(+e.target.value)}
+            onChange={(n) => setTimeMinutes(n ?? 0)}
             min={0}
           />
         </div>
         <div>
           <label className={labelCls}>Servings</label>
-          <input
-            type="number"
-            inputMode="numeric"
+          <NumberInput
             className={inputCls}
             value={servings}
-            onChange={(e) => setServings(Math.max(1, +e.target.value || 1))}
+            onChange={(n) => setServings(n == null || n < 1 ? 1 : n)}
             min={1}
             max={50}
           />
@@ -502,11 +499,40 @@ function StepsStep({
   setInstructions: (v: Instruction[]) => void;
   ingredients: Ingredient[];
 }) {
+  // Find ingredients that have a name but aren't tagged in any step yet.
+  // Hides until the user has at least one step + one ingredient — the
+  // warning is irrelevant before then.
+  const usedIdx = new Set<number>();
+  for (const step of instructions) {
+    for (const idx of step.ingredientIndexes ?? []) usedIdx.add(idx);
+  }
+  const unused = ingredients
+    .map((ing, idx) => ({ ing, idx }))
+    .filter(({ ing }) => ing.name.trim().length > 0)
+    .filter(({ idx }) => !usedIdx.has(idx))
+    .map(({ ing }) => ing.name.trim());
+
+  const showWarning = instructions.some((s) => s.text.trim()) && unused.length > 0;
+
   return (
     <div className="space-y-3">
       <p className="text-sm text-zinc-400">
         Write each step and tag which ingredients it uses.
       </p>
+      {showWarning && (
+        <div
+          role="status"
+          className="bg-amber-500/10 border border-amber-500/30 text-amber-200 text-xs rounded-lg px-3 py-2 flex items-start gap-2"
+        >
+          <span aria-hidden="true">⚠</span>
+          <p className="flex-1">
+            <span className="font-semibold">
+              {unused.length} {unused.length === 1 ? 'ingredient isn’t' : 'ingredients aren’t'} used in any step:
+            </span>{' '}
+            <span className="text-amber-100">{unused.join(', ')}</span>
+          </p>
+        </div>
+      )}
       <InstructionsEditor
         steps={instructions}
         ingredients={ingredients}
@@ -656,12 +682,10 @@ function FinishStep({
               <span className="text-[10px] uppercase tracking-wider text-zinc-500">
                 {label}
               </span>
-              <input
-                type="number"
-                inputMode="numeric"
+              <NumberInput
                 className={inputCls}
                 value={val}
-                onChange={(e) => setter(+e.target.value)}
+                onChange={(n) => setter(n ?? 0)}
                 min={0}
               />
             </div>


### PR DESCRIPTION
Two UX fixes from real-world testing.

## NumberInput
Bare type=number inputs snap to 0 when you backspace the existing value, which made changing a 1-default field (servings, time) frustrating on phones — especially since iOS doesn't easily let you select-then-replace inside a number input.

New NumberInput keeps a local string draft so:
- backspacing leaves the field briefly empty without rewriting state to 0
- tap-and-type works because we select-all on focus
- inputMode is 'numeric' (integer) or 'decimal' so the right keypad shows
- on blur it parses, clamps to min/max, and commits to the parent
- when parent value changes externally (e.g., auto-calc fills it), the field syncs

Used everywhere a recipe field is numeric: Time, Servings, Macros (4), ingredient amount.

## Step warning
On the wizard's Steps step, once you have at least one step and at least one ingredient, an amber chip lists ingredients not yet tagged in any step. Quiet until both prerequisites are present so it doesn't nag empty forms.

## Test plan
- [ ] Tap the Servings field showing '1' and type 5 → field shows '5' (no '15')
- [ ] Backspace the Servings field → field empties briefly; tap away → snaps to 1 (the min)
- [ ] iPhone Safari: numeric keyboard appears for Time/Servings/Macros; decimal keyboard for ingredient qty
- [ ] Add 3 ingredients then 1 step that tags only 2 of them → amber warning lists the third by name