### PR TITLE
fix(profile): self-resolution + picker tweaks + bigger remove tap target

### DIFF
--- a/src/components/CookForm.tsx
+++ b/src/components/CookForm.tsx
@@ -361,21 +361,26 @@ function PeopleSection({
               ? 'You'
               : name || (handle ? `@${handle}` : `${id.slice(0, 6)}…`);
             return (
-              <button
+              <span
                 key={id}
-                type="button"
-                onClick={() => (isMe ? undefined : onRemove(id))}
-                disabled={isMe}
-                className={`text-xs px-2.5 py-1 rounded-full border transition ${
+                className={`inline-flex items-center text-xs rounded-full border ${
                   isMe
-                    ? 'bg-coral-500/30 border-coral-500/60 text-coral-100 cursor-default'
-                    : 'bg-coral-500/20 border-coral-500/50 text-coral-200 hover:bg-coral-500/30'
+                    ? 'bg-coral-500/30 border-coral-500/60 text-coral-100'
+                    : 'bg-coral-500/20 border-coral-500/50 text-coral-200'
                 }`}
-                aria-label={isMe ? 'You (always included)' : `Remove ${display}`}
               >
-                {display}
-                {!isMe && <span className="ml-1 text-coral-300/70">×</span>}
-              </button>
+                <span className="px-2.5 py-1.5">{display}</span>
+                {!isMe && (
+                  <button
+                    type="button"
+                    onClick={() => onRemove(id)}
+                    aria-label={`Remove ${display}`}
+                    className="h-7 w-7 grid place-items-center text-base text-coral-200 hover:bg-coral-500/30 rounded-r-full transition focus:outline-none focus:ring-2 focus:ring-coral-400/50"
+                  >
+                    ×
+                  </button>
+                )}
+              </span>
             );
           })}
         </div>

--- a/src/components/PeoplePickerModal.tsx
+++ b/src/components/PeoplePickerModal.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useFriends } from '@/lib/hooks';
 import { useUsersById } from '@/lib/use-users-by-id';
+import { useAuth } from '@/lib/auth-context';
 import { usersSearchApi } from '@/lib/api';
 import { PublicUserProfile } from '@/lib/users';
 
@@ -35,6 +36,8 @@ export default function PeoplePickerModal({
   const [searchResults, setSearchResults] = useState<PublicUserProfile[]>([]);
   const [searching, setSearching] = useState(false);
 
+  const { user } = useAuth();
+  const callerSub = user?.sub ?? null;
   const { friends } = useFriends();
   // Resolve display profiles for friends + selected (selected may include
   // non-friends if the picker was used with handle search).
@@ -116,8 +119,13 @@ export default function PeoplePickerModal({
   });
 
   const seenInLists = new Set<string>([...selected, ...visibleFriendIds]);
+  // Self never shows up in search — the caller is always pinned as a chef
+  // by the consuming form, so listing themselves here is just confusing.
   const searchOnlyResults = searchResults.filter(
-    (u) => !seenInLists.has(u.userId) && !exclude.has(u.userId),
+    (u) =>
+      !seenInLists.has(u.userId) &&
+      !exclude.has(u.userId) &&
+      u.userId !== callerSub,
   );
 
   const selectedRows: { userId: string; profile: PublicUserProfile | undefined }[] = selected.map(

--- a/src/lib/use-users-by-id.ts
+++ b/src/lib/use-users-by-id.ts
@@ -1,7 +1,9 @@
 'use client';
+import { useMemo } from 'react';
 import useSWR from 'swr';
 import { usersApi, PublicUserProfile } from './users';
 import { useAuth } from './auth-context';
+import { useProfile } from './use-profile';
 
 /**
  * Resolve a list of Cognito subs to public profile slices, with SWR
@@ -10,28 +12,59 @@ import { useAuth } from './auth-context';
  * row userIds, etc.) and get back a Map<userId, profile> they can
  * pluck from at render time.
  *
- * Filters falsy/duplicate ids upfront so callers don't have to.
+ * The caller's own profile is overlaid from useProfile() so we never
+ * fall back to a stub for self — earlier this caused the feed cards
+ * to render "?" + "Someone cooked X" for the signed-in user's own
+ * cooks, which was disorienting.
  */
 export function useUsersById(userIds: (string | null | undefined)[]) {
-  const { isAuthenticated } = useAuth();
-  const ids = [...new Set(userIds.filter((id): id is string => !!id))].sort();
-  const key = isAuthenticated && ids.length > 0 ? ['users:batch-get', ids.join(',')] : null;
+  const { isAuthenticated, user } = useAuth();
+  const { profile: self } = useProfile();
+  const callerSub = user?.sub ?? null;
+
+  const ids = useMemo(
+    () => [...new Set(userIds.filter((id): id is string => !!id))].sort(),
+    [userIds],
+  );
+  // Don't bother batch-getting the caller — we already have a richer
+  // profile via /users/me.
+  const idsToFetch = useMemo(
+    () => (callerSub ? ids.filter((id) => id !== callerSub) : ids),
+    [ids, callerSub],
+  );
+
+  const key =
+    isAuthenticated && idsToFetch.length > 0
+      ? ['users:batch-get', idsToFetch.join(',')]
+      : null;
   const { data, error, isLoading } = useSWR(
     key,
-    () => usersApi.batchGet(ids),
+    () => usersApi.batchGet(idsToFetch),
     { revalidateOnFocus: false, dedupingInterval: 60_000 },
   );
 
   const map = new Map<string, PublicUserProfile>();
   for (const u of data ?? []) map.set(u.userId, u);
+  // Overlay the caller's own profile so anything that asks "who is this
+  // user?" gets a real name + avatar instead of falling back to a
+  // truncated UUID.
+  if (callerSub && self && ids.includes(callerSub)) {
+    map.set(callerSub, {
+      userId: callerSub,
+      preferredUsername: self.preferredUsername,
+      displayName: self.displayName,
+      avatarUrl: self.avatarUrl,
+      avatarStockColor: self.avatarStockColor,
+      profileVisibility: self.profileVisibility,
+    });
+  }
 
   return { map, isLoading: isAuthenticated ? isLoading : false, error };
 }
 
 /**
  * Compose a display label from a public profile, falling back through
- * displayName -> @handle -> email-style userId stub. Mirrors the same
- * order Header's `userLabel` getter uses.
+ * displayName -> @handle -> generic "a chef".
  */
 export function userLabel(p: PublicUserProfile | undefined | null): string {
   if (!p) return 'someone';


### PR DESCRIPTION
Three feedback items rolled into one:

## Self never falls back to '?' or a UUID stub
`useUsersById` now overlays the caller's own profile from `useProfile` (`/users/me`). Anywhere a component asks 'who is this user?' for the signed-in user, it gets the real name + avatar instead of relying on the cross-app batch-get round trip. Fixes the disorienting feed card 'Someone cooked X' for your own cook + the '?' avatar.

## Picker stops listing the caller
`PeoplePickerModal` filters self out of the handle-search results — the consuming form (CookForm) already pins them as a chef, so showing them again under 'Other people' just confused the UX (and showed the truncated UUID since search results don't always have a full profile).

## Bigger remove tap target on chefs/diners chips
The chip ' × ' is now a real button, ~28px square, separated from the label so a thumb can hit it without retrying.

## Test plan
- [ ] Sign in, log a cook of an existing recipe → feed card shows your real avatar + 'Dominick cooked X' instead of '?' + 'Someone cooked X'
- [ ] /cooks/new on phone → 'Who cooked' chip shows you with avatar + display name; tap-and-search a friend's handle, your own handle never appears in 'Other people'
- [ ] Tap the × on a non-self chip — easy to hit; chip removes