### PR TITLE
feat(ratings): cook wizard captures all 5 axes; recipe page is read-only

### DIFF
--- a/src/app/cooks/new/page.tsx
+++ b/src/app/cooks/new/page.tsx
@@ -41,6 +41,10 @@ function NewCookInner() {
       notes: values.notes || undefined,
       photoUrl: values.photoUrl,
       rating: values.rating,
+      spiciness: values.spiciness,
+      sweetness: values.sweetness,
+      saltiness: values.saltiness,
+      richness: values.richness,
     });
     router.push(`/cooks/view?id=${encodeURIComponent(cook.cookId)}`);
   };

--- a/src/app/cooks/view/page.tsx
+++ b/src/app/cooks/view/page.tsx
@@ -6,7 +6,7 @@ import { useRequireAuth, useAuth } from '@/lib/auth-context';
 import { useCook, useRecipe } from '@/lib/hooks';
 import { useUsersById } from '@/lib/use-users-by-id';
 import { CookForm, CookFormValues } from '@/components/CookForm';
-import { RatingStars } from '@/components/RatingStars';
+import { IconRating, RATING_AXES } from '@/components/IconRating';
 import { CookComments } from '@/components/CookComments';
 import Loader from '@/components/Loader';
 import { PublicUserProfile } from '@/lib/users';
@@ -52,6 +52,10 @@ function CookViewInner() {
       notes: values.notes,
       photoUrl: values.photoUrl,
       rating: values.rating,
+      spiciness: values.spiciness,
+      sweetness: values.sweetness,
+      saltiness: values.saltiness,
+      richness: values.richness,
     });
     setEditing(false);
   };
@@ -96,6 +100,10 @@ function CookViewInner() {
                 notes: cook.notes,
                 photoUrl: cook.photoUrl,
                 rating: cook.rating,
+                spiciness: cook.spiciness,
+                sweetness: cook.sweetness,
+                saltiness: cook.saltiness,
+                richness: cook.richness,
               }}
               showCookedAt
               cookedAtImmutable
@@ -149,17 +157,36 @@ function CookViewInner() {
             />
           )}
 
-          {cook.rating != null ? (
-            <div className="flex items-center gap-3">
-              <span className="text-xs uppercase tracking-wider text-zinc-400 font-semibold">
-                Rating
-              </span>
-              <RatingStars value={cook.rating} size="sm" readOnly />
-              <span className="chef-stamp text-base">{cook.rating}/5</span>
+          <div className="space-y-2 pt-1">
+            <div className="text-xs uppercase tracking-wider text-zinc-400 font-semibold">
+              Ratings
             </div>
-          ) : (
-            <div className="text-xs text-zinc-500 italic">Not rated.</div>
-          )}
+            {RATING_AXES.every((a) =>
+              ((cook as unknown as Record<string, number | null>)[a.key === 'overall' ? 'rating' : a.key] ?? null) === null,
+            ) ? (
+              <div className="text-xs text-zinc-500 italic">Not rated.</div>
+            ) : (
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                {RATING_AXES.map((axis) => {
+                  const cookKey = axis.key === 'overall' ? 'rating' : axis.key;
+                  const v = (cook as unknown as Record<string, number | null>)[cookKey];
+                  return (
+                    <div
+                      key={axis.key}
+                      className="flex items-center justify-between bg-zinc-950/50 border border-zinc-800 rounded-lg px-3 py-2"
+                    >
+                      <span className="text-xs text-zinc-300 font-semibold">{axis.label}</span>
+                      {v != null ? (
+                        <IconRating value={v} icon={axis.icon} size="sm" readOnly />
+                      ) : (
+                        <span className="text-[11px] text-zinc-600 italic">—</span>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
 
           {cook.notes ? (
             <div>

--- a/src/app/recipes/view/page.tsx
+++ b/src/app/recipes/view/page.tsx
@@ -18,10 +18,8 @@ import {
   instructionText,
   normalizeInstruction,
 } from '@/types';
-import { recipesApi } from '@/lib/api';
 import Loader from '@/components/Loader';
-import { IconRating, RATING_AXES, RatingAxisKey } from '@/components/IconRating';
-import { RateAxes } from '@/lib/api';
+import { IconRating, RATING_AXES } from '@/components/IconRating';
 
 export default function RecipeViewPage() {
   return (
@@ -37,16 +35,8 @@ function RecipeViewInner() {
   const recipeId = params.get('id');
   const { isAuthenticated, isLoading: authLoading } = useRequireAuth();
   const { user } = useAuth();
-  const { recipe, isLoading, error, refresh, edit, remove } = useRecipe(recipeId);
+  const { recipe, isLoading, error, edit, remove } = useRecipe(recipeId);
   const [editing, setEditing] = useState(false);
-  const [myRatings, setMyRatings] = useState<Record<RatingAxisKey, number>>({
-    overall: 0,
-    spiciness: 0,
-    sweetness: 0,
-    saltiness: 0,
-    richness: 0,
-  });
-  const [ratingSubmitting, setRatingSubmitting] = useState(false);
 
   if (authLoading || !isAuthenticated) {
     return <Loader fullscreen />;
@@ -73,18 +63,6 @@ function RecipeViewInner() {
   }
 
   const isAuthor = user?.sub === recipe.authorUserId;
-
-  const handleRate = async (axisKey: RatingAxisKey, n: number) => {
-    setMyRatings((prev) => ({ ...prev, [axisKey]: n }));
-    setRatingSubmitting(true);
-    const axisCfg = RATING_AXES.find((a) => a.key === axisKey)!;
-    try {
-      await recipesApi.rate(recipe.recipeId, { [axisCfg.bodyKey]: n } as RateAxes);
-      refresh();
-    } finally {
-      setRatingSubmitting(false);
-    }
-  };
 
   const handleDelete = async () => {
     if (typeof window !== 'undefined') {
@@ -259,37 +237,40 @@ function RecipeViewInner() {
           )}
 
           <div className="pt-2 border-t border-zinc-800 space-y-3">
-            {RATING_AXES.map((axis) => {
-              const avg = (recipe as unknown as Record<string, number | null>)[axis.avgKey];
-              const count = (recipe as unknown as Record<string, number>)[axis.countKey] ?? 0;
-              const my = myRatings[axis.key];
-              return (
-                <div key={axis.key} className="flex items-center justify-between gap-3">
-                  <div>
-                    <div className="text-xs uppercase tracking-wider text-zinc-400 font-semibold">
-                      {axis.label}
+            <div className="text-xs uppercase tracking-wider text-zinc-400 font-semibold">
+              Ratings
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              {RATING_AXES.map((axis) => {
+                const avg = (recipe as unknown as Record<string, number | null>)[axis.avgKey];
+                const count = (recipe as unknown as Record<string, number>)[axis.countKey] ?? 0;
+                return (
+                  <div
+                    key={axis.key}
+                    className="flex items-center justify-between bg-zinc-950/50 border border-zinc-800 rounded-lg px-3 py-2"
+                  >
+                    <div>
+                      <div className="text-xs text-zinc-300 font-semibold">
+                        {axis.label}
+                      </div>
+                      <div className="text-[10px] text-zinc-500">
+                        {count > 0 && avg != null
+                          ? `avg ${avg.toFixed(1)} · ${count}`
+                          : 'no ratings yet'}
+                      </div>
                     </div>
                     {count > 0 && avg != null ? (
-                      <p className="text-[11px] text-zinc-500 mt-0.5">
-                        avg {avg.toFixed(1)} · {count} {count === 1 ? 'rating' : 'ratings'}
-                      </p>
+                      <IconRating value={Math.round(avg)} icon={axis.icon} size="sm" readOnly />
                     ) : (
-                      <p className="text-[11px] text-zinc-500 mt-0.5">no ratings yet</p>
+                      <span className="text-[11px] text-zinc-600 italic">—</span>
                     )}
                   </div>
-                  <IconRating
-                    value={my}
-                    onChange={(n) => void handleRate(axis.key, n)}
-                    icon={axis.icon}
-                    size="md"
-                    label={`Rate ${axis.label.toLowerCase()}`}
-                  />
-                </div>
-              );
-            })}
-            {ratingSubmitting && (
-              <div className="text-[11px] text-zinc-500 italic">Saving…</div>
-            )}
+                );
+              })}
+            </div>
+            <p className="text-[11px] text-zinc-500 italic">
+              Want to rate? Log a cook of this recipe — ratings live on the cook session.
+            </p>
           </div>
         </section>
 

--- a/src/components/CookForm.tsx
+++ b/src/components/CookForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useMemo, useState } from 'react';
-import { RatingStars } from './RatingStars';
+import { IconRating, RATING_AXES, RatingAxisKey } from './IconRating';
 import PeoplePickerModal from './PeoplePickerModal';
 import { useUsersById } from '@/lib/use-users-by-id';
 import { useAuth } from '@/lib/auth-context';
@@ -18,6 +18,10 @@ export interface CookFormValues {
   notes: string;
   photoUrl: string | null;
   rating: number | null;
+  spiciness: number | null;
+  sweetness: number | null;
+  saltiness: number | null;
+  richness: number | null;
 }
 
 interface Props {
@@ -68,7 +72,15 @@ export function CookForm({
   const [diners, setDiners] = useState<string[]>(initial?.diners ?? []);
   const [notes, setNotes] = useState(initial?.notes ?? '');
   const [photoUrl, setPhotoUrl] = useState(initial?.photoUrl ?? '');
-  const [rating, setRating] = useState<number>(initial?.rating ?? 0);
+  const [ratings, setRatings] = useState<Record<RatingAxisKey, number>>({
+    overall: initial?.rating ?? 0,
+    spiciness: initial?.spiciness ?? 0,
+    sweetness: initial?.sweetness ?? 0,
+    saltiness: initial?.saltiness ?? 0,
+    richness: initial?.richness ?? 0,
+  });
+  const setRating = (axis: RatingAxisKey, n: number) =>
+    setRatings((prev) => ({ ...prev, [axis]: n }));
 
   const [stepId, setStepId] = useState<StepId>(participantsImmutable ? 'details' : 'who');
   const [submitting, setSubmitting] = useState(false);
@@ -99,16 +111,18 @@ export function CookForm({
     setSubmitting(true);
     setError(null);
     try {
-      // Diners can't also be chefs — backend filters this but we mirror it
-      // here so the UI never sends an obviously bad payload.
-      const cleanedDiners = diners.filter((d) => !chefs.includes(d));
+      const r = (n: number) => (n > 0 ? n : null);
       await onSubmit({
         cookedAt: new Date(cookedAt).toISOString(),
         chefs,
-        diners: cleanedDiners,
+        diners,
         notes: notes.trim(),
         photoUrl: photoUrl.trim() || null,
-        rating: rating > 0 ? rating : null,
+        rating: r(ratings.overall),
+        spiciness: r(ratings.spiciness),
+        sweetness: r(ratings.sweetness),
+        saltiness: r(ratings.saltiness),
+        richness: r(ratings.richness),
       });
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Save failed');
@@ -160,7 +174,7 @@ export function CookForm({
         )}
 
         {stepId === 'rating' && (
-          <RatingStep rating={rating} setRating={setRating} />
+          <RatingStep ratings={ratings} setRating={setRating} />
         )}
 
         {error && (
@@ -434,29 +448,53 @@ function DetailsStep({
 // ---------- Step 3: Rating ----------
 
 function RatingStep({
-  rating,
+  ratings,
   setRating,
 }: {
-  rating: number;
-  setRating: (n: number) => void;
+  ratings: Record<RatingAxisKey, number>;
+  setRating: (axis: RatingAxisKey, n: number) => void;
 }) {
   return (
-    <div className="space-y-3">
-      <span className={labelCls}>How was this cook?</span>
-      <div className="flex items-center gap-3">
-        <RatingStars value={rating} onChange={setRating} size="lg" label="Cook rating" />
-        {rating > 0 && (
-          <button
-            type="button"
-            onClick={() => setRating(0)}
-            className="text-xs text-zinc-500 hover:text-coral-300 transition"
-          >
-            clear
-          </button>
-        )}
-      </div>
-      <p className="text-[11px] text-zinc-500">
-        Optional — rate this specific cook session. Recipe ratings live on the recipe page.
+    <div className="space-y-4">
+      <p className="text-sm text-zinc-400">
+        Rate how this cook turned out. All optional — skip whatever doesn't apply.
+      </p>
+      {RATING_AXES.map((axis) => {
+        const v = ratings[axis.key];
+        return (
+          <div key={axis.key} className="flex items-center justify-between gap-3">
+            <div>
+              <div className="text-xs uppercase tracking-wider text-zinc-400 font-semibold">
+                {axis.label}
+              </div>
+              <div className="text-[11px] text-zinc-500">
+                {v > 0 ? `${v}/5` : 'not rated'}
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <IconRating
+                value={v}
+                onChange={(n) => setRating(axis.key, n)}
+                icon={axis.icon}
+                size="md"
+                label={`Rate ${axis.label.toLowerCase()}`}
+              />
+              {v > 0 && (
+                <button
+                  type="button"
+                  onClick={() => setRating(axis.key, 0)}
+                  aria-label={`Clear ${axis.label.toLowerCase()} rating`}
+                  className="text-xs text-zinc-500 hover:text-coral-300 transition px-1"
+                >
+                  ×
+                </button>
+              )}
+            </div>
+          </div>
+        );
+      })}
+      <p className="text-[11px] text-zinc-500 italic">
+        These ratings roll up into the recipe's overall numbers — you can only rate a recipe if you've cooked it.
       </p>
     </div>
   );

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -200,12 +200,20 @@ export interface LogCookInput {
   notes?: string;
   photoUrl?: string | null;
   rating?: number | null;
+  spiciness?: number | null;
+  sweetness?: number | null;
+  saltiness?: number | null;
+  richness?: number | null;
 }
 
 export interface EditCookInput {
   notes?: string;
   photoUrl?: string | null;
   rating?: number | null;
+  spiciness?: number | null;
+  sweetness?: number | null;
+  saltiness?: number | null;
+  richness?: number | null;
 }
 
 export type CookListScope = 'mine' | 'recipe';

--- a/src/types.ts
+++ b/src/types.ts
@@ -230,6 +230,10 @@ export interface Cook {
   notes: string;
   photoUrl: string | null;
   rating: number | null;
+  spiciness: number | null;
+  sweetness: number | null;
+  saltiness: number | null;
+  richness: number | null;
   loggedByUserId: string;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
Pairs with [xomappetit-backend#28](https://github.com/Xomware/xomappetit-backend/pull/28). Ratings now live on the cook session — the recipe page shows aggregates as read-only filled icons, and the wizard's rating step asks for all 5 axes.

### CookForm rating step
All 5 axes (overall ⭐ / spice 🌶️ / sweet 🍯 / salt 🧂 / rich 🧈) via IconRating, each with an inline × to clear.

### /cooks/view
2-up grid of per-axis filled bars, one row per axis the chef rated. Empty axes render as '—'.

### /recipes/view
Drops the inline rating UI. Aggregates render as read-only filled icons + 'avg X · N'. Hint at the bottom: 'Want to rate? Log a cook of this recipe.'

### Type + API
Cook + LogCookInput + EditCookInput grow the new axis fields.

## Test plan
- [ ] /cooks/new wizard step 3: 5 axis rows, each tappable
- [ ] /cooks/view shows the 5-axis grid
- [ ] /recipes/view ratings section is read-only