### PR TITLE
feat(feed): single-column social layout instead of square grid

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -31,7 +31,7 @@ export default function Feed() {
   const { map: users } = useUsersById(userIds);
 
   return (
-    <main className="max-w-6xl mx-auto px-4 py-6 space-y-6">
+    <main className="max-w-xl mx-auto px-4 py-6 space-y-6">
       <div className="flex items-end justify-between gap-4 flex-wrap">
         <div>
           <h2 className="font-display text-2xl font-black uppercase tracking-wide">Feed</h2>
@@ -62,7 +62,7 @@ export default function Feed() {
       ) : items.length === 0 ? (
         <EmptyFeed friendCount={friendCount} />
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        <div className="flex flex-col gap-5">
           {items.map((item) => {
             if (item.type === 'cook') {
               const chef = users.get(item.cook.chefs[0]) || users.get(item.recipe.authorUserId);
@@ -80,6 +80,7 @@ export default function Feed() {
                 key={`recipe-${item.recipe.recipeId}`}
                 recipe={item.recipe}
                 author={users.get(item.recipe.authorUserId)}
+                variant="feed"
               />
             );
           })}

--- a/src/components/CookActivityCard.tsx
+++ b/src/components/CookActivityCard.tsx
@@ -11,11 +11,11 @@ interface Props {
 }
 
 /**
- * Feed item shape for "X cooked Recipe Y on Z". Distinct visual from
- * RecipeCard so the user reads the feed as activity, not catalog.
+ * Social-feed post for "X cooked Recipe Y": author header, the recipe being
+ * made, an optional hero photo, notes, and a stats row. Visually distinct
+ * from RecipeCard so the feed reads as activity, not catalog.
  *
- * Tap goes to the cook detail (`/cooks/view`), with a secondary link
- * to the recipe itself in the body.
+ * Tap goes to the cook detail (`/cooks/view`).
  */
 export function CookActivityCard({ cook, recipe, chef }: Props) {
   const date = new Date(cook.cookedAt).toLocaleDateString(undefined, {
@@ -27,14 +27,16 @@ export function CookActivityCard({ cook, recipe, chef }: Props) {
   const chefName = chef?.displayName;
   const chefAvatar = chef?.avatarUrl;
   const chefInitial = (chefName || chefHandle || '?').charAt(0).toUpperCase();
+  const chefLabel = chefName || (chefHandle ? `@${chefHandle}` : 'Someone');
 
   return (
     <Link
       href={`/cooks/view?id=${encodeURIComponent(cook.cookId)}`}
-      className="group block bg-zinc-900/60 border-l-2 border-coral-500/50 border-t border-r border-b border-zinc-800 hover:border-coral-500/50 rounded-xl p-4 transition focus:outline-none focus:ring-2 focus:ring-coral-400/50"
+      className="group block bg-zinc-900/60 border border-zinc-800 hover:border-coral-500/50 rounded-2xl overflow-hidden transition hover:shadow-lg hover:shadow-coral-500/10 focus:outline-none focus:ring-2 focus:ring-coral-400/50"
     >
-      <div className="flex items-start gap-3">
-        <div className="h-10 w-10 rounded-full overflow-hidden bg-zinc-800 border border-zinc-700 grid place-items-center text-white text-xl shrink-0">
+      {/* Header */}
+      <div className="flex items-center gap-3 p-5 pb-3">
+        <div className="h-9 w-9 rounded-full overflow-hidden bg-zinc-800 border border-zinc-700 grid place-items-center text-white shrink-0">
           {chefAvatar ? (
             // eslint-disable-next-line @next/next/no-img-element
             <img src={chefAvatar} alt="" className="h-full w-full object-cover" />
@@ -45,37 +47,54 @@ export function CookActivityCard({ cook, recipe, chef }: Props) {
           )}
         </div>
         <div className="min-w-0 flex-1">
-          <p className="text-xs text-zinc-500 uppercase tracking-wider font-semibold mb-0.5">
-            Cook session · {date}
+          <p className="text-sm leading-tight truncate">
+            <span className="font-semibold text-coral-400">{chefLabel}</span>
+            <span className="text-zinc-400"> cooked this</span>
           </p>
-          <h3 className="font-bold text-base text-zinc-100 truncate group-hover:text-coral-300 transition">
-            {chefHandle ? (
-              <>
-                <span className="text-coral-400">{chefName || `@${chefHandle}`}</span>{' '}
-                <span className="text-zinc-400 font-normal">cooked</span>{' '}
-                {recipe.name}
-              </>
-            ) : (
-              <>Someone cooked {recipe.name}</>
-            )}
-          </h3>
-          {cook.notes && (
-            <p className="text-sm text-zinc-300 mt-1 line-clamp-2">{cook.notes}</p>
+          <p className="text-xs text-zinc-500 leading-tight mt-0.5">{date}</p>
+        </div>
+        <span className="text-[11px] uppercase tracking-wider text-zinc-600 font-semibold shrink-0">
+          Cook
+        </span>
+      </div>
+
+      {/* Recipe being cooked */}
+      <div className="px-5 pb-3">
+        <h3 className="font-display text-lg font-black tracking-wide text-zinc-100 group-hover:text-coral-300 transition">
+          {recipe.name}
+        </h3>
+      </div>
+
+      {/* Hero photo (full-bleed) */}
+      {cook.photoUrl && (
+        <div className="border-y border-zinc-800 bg-zinc-950">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={cook.photoUrl}
+            alt={`${chefLabel}'s cook of ${recipe.name}`}
+            className="w-full aspect-[4/3] object-cover"
+          />
+        </div>
+      )}
+
+      {/* Body */}
+      <div className={`px-5 pb-5 ${cook.photoUrl ? 'pt-4' : 'pt-0'}`}>
+        {cook.notes && (
+          <p className="text-sm text-zinc-300 line-clamp-3">{cook.notes}</p>
+        )}
+        <div className="text-xs text-zinc-500 flex items-center gap-4 mt-3">
+          {cook.rating != null && (
+            <span className="flex items-center gap-1">
+              <span className="text-coral-300">★</span>
+              <span className="text-zinc-300 font-semibold">{cook.rating}/5</span>
+            </span>
           )}
-          <div className="text-xs text-zinc-500 flex items-center gap-3 mt-2">
-            {cook.rating != null && (
-              <span className="flex items-center gap-1">
-                <span className="text-coral-300">★</span>
-                <span className="text-zinc-300 font-semibold">{cook.rating}/5</span>
-              </span>
-            )}
-            {cook.diners.length > 0 && (
-              <span>
-                <span className="text-zinc-300 font-semibold">{cook.diners.length}</span>{' '}
-                {cook.diners.length === 1 ? 'diner' : 'diners'}
-              </span>
-            )}
-          </div>
+          {cook.diners.length > 0 && (
+            <span>
+              <span className="text-zinc-300 font-semibold">{cook.diners.length}</span>{' '}
+              {cook.diners.length === 1 ? 'diner' : 'diners'}
+            </span>
+          )}
         </div>
       </div>
     </Link>

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -9,9 +9,14 @@ interface Props {
   recipe: Recipe;
   /** Public profile of the recipe author, when resolved. */
   author?: PublicUserProfile | null;
+  /**
+   * 'grid' (default) — compact card for the discover/search/profile grids.
+   * 'feed' — full-width social-style post for the home feed.
+   */
+  variant?: 'grid' | 'feed';
 }
 
-export function RecipeCard({ recipe, author }: Props) {
+export function RecipeCard({ recipe, author, variant = 'grid' }: Props) {
   const handle = author?.preferredUsername ?? recipe.authorHandle ?? null;
   const name = author?.displayName ?? null;
   const avatarUrl = author?.avatarUrl ?? null;
@@ -19,6 +24,97 @@ export function RecipeCard({ recipe, author }: Props) {
   // Difficulty is 1..5 going forward, but back-compat for any unmigrated rows.
   const diff = typeof recipe.difficulty === 'number' ? recipe.difficulty : 3;
   const tags = recipe.tags ?? [];
+
+  const meta = (
+    <div className="text-xs flex items-center gap-1.5 text-zinc-400">
+      <DifficultyDots value={diff} />
+      {recipe.timeMinutes > 0 && (
+        <>
+          <span className="text-zinc-700">·</span>
+          <span>{recipe.timeMinutes}m</span>
+        </>
+      )}
+      {recipe.servings > 0 && (
+        <>
+          <span className="text-zinc-700">·</span>
+          <span>{recipe.servings} {recipe.servings === 1 ? 'serv' : 'servs'}</span>
+        </>
+      )}
+    </div>
+  );
+
+  const stats = (
+    <div className="text-xs text-zinc-500 flex items-center gap-3 min-w-0">
+      <LikeButton
+        recipeId={recipe.recipeId}
+        initialCount={recipe.likeCount ?? 0}
+        initialLiked={recipe.likedByMe ?? false}
+        compact
+      />
+      <span className="truncate">
+        <span className="text-zinc-300 font-semibold">{recipe.cookCount}</span>{' '}
+        {recipe.cookCount === 1 ? 'cook' : 'cooks'}
+      </span>
+      {recipe.ratingCount > 0 && recipe.avgRating != null && (
+        <span className="flex items-center gap-1 shrink-0">
+          <span className="text-coral-300">★</span>
+          <span className="text-zinc-300 font-semibold">{recipe.avgRating.toFixed(1)}</span>
+        </span>
+      )}
+    </div>
+  );
+
+  // ---- Feed variant: full-width social post -------------------------------
+  if (variant === 'feed') {
+    return (
+      <Link
+        href={`/recipes/view?id=${encodeURIComponent(recipe.recipeId)}`}
+        className="group block bg-zinc-900/60 border border-zinc-800 hover:border-coral-500/50 rounded-2xl p-5 transition hover:shadow-lg hover:shadow-coral-500/10 focus:outline-none focus:ring-2 focus:ring-coral-400/50"
+      >
+        {/* Author header */}
+        <div className="flex items-center gap-3 mb-3">
+          <AuthorChip handle={handle} name={name} avatarUrl={avatarUrl} initial={initial} />
+          <div className="ml-auto flex items-center gap-2">
+            <span className="text-[11px] uppercase tracking-wider text-zinc-600 font-semibold">
+              Recipe
+            </span>
+            <PrivacyBadge privacy={recipe.privacy} />
+          </div>
+        </div>
+
+        <h3 className="font-display text-xl font-black tracking-wide text-zinc-100 group-hover:text-coral-300 transition">
+          {recipe.name}
+        </h3>
+        <div className="mt-1.5">{meta}</div>
+
+        {recipe.description && (
+          <p className="text-sm text-zinc-400 line-clamp-3 mt-2">{recipe.description}</p>
+        )}
+
+        {tags.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 mt-3">
+            {tags.slice(0, 6).map((t) => (
+              <span
+                key={t}
+                className="inline-block bg-zinc-800/80 text-zinc-300 text-[11px] px-2 py-0.5 rounded-full"
+              >
+                {TAG_LABELS[t] ?? t}
+              </span>
+            ))}
+            {tags.length > 6 && (
+              <span className="inline-block text-[11px] text-zinc-500 px-1 py-0.5">
+                +{tags.length - 6}
+              </span>
+            )}
+          </div>
+        )}
+
+        <div className="flex items-center pt-3 mt-3 border-t border-zinc-800/60">{stats}</div>
+      </Link>
+    );
+  }
+
+  // ---- Grid variant (default): compact catalog card -----------------------
   return (
     <Link
       href={`/recipes/view?id=${encodeURIComponent(recipe.recipeId)}`}
@@ -29,21 +125,7 @@ export function RecipeCard({ recipe, author }: Props) {
           <h3 className="font-bold text-base truncate group-hover:text-coral-300 transition">
             {recipe.name}
           </h3>
-          <div className="text-xs flex items-center gap-1.5 mt-0.5 text-zinc-400">
-            <DifficultyDots value={diff} />
-            {recipe.timeMinutes > 0 && (
-              <>
-                <span className="text-zinc-700">·</span>
-                <span>{recipe.timeMinutes}m</span>
-              </>
-            )}
-            {recipe.servings > 0 && (
-              <>
-                <span className="text-zinc-700">·</span>
-                <span>{recipe.servings} {recipe.servings === 1 ? 'serv' : 'servs'}</span>
-              </>
-            )}
-          </div>
+          <div className="mt-0.5">{meta}</div>
         </div>
         <PrivacyBadge privacy={recipe.privacy} />
       </div>
@@ -71,52 +153,76 @@ export function RecipeCard({ recipe, author }: Props) {
       )}
 
       <div className="flex items-center justify-between pt-1 border-t border-zinc-800/60 gap-2">
-        <div className="text-xs text-zinc-500 flex items-center gap-3 min-w-0">
-          <LikeButton
-            recipeId={recipe.recipeId}
-            initialCount={recipe.likeCount ?? 0}
-            initialLiked={recipe.likedByMe ?? false}
-            compact
-          />
-          <span className="truncate">
-            <span className="text-zinc-300 font-semibold">{recipe.cookCount}</span>{' '}
-            {recipe.cookCount === 1 ? 'cook' : 'cooks'}
-          </span>
-          {recipe.ratingCount > 0 && recipe.avgRating != null && (
-            <span className="flex items-center gap-1 shrink-0">
-              <span className="text-coral-300">★</span>
-              <span className="text-zinc-300 font-semibold">
-                {recipe.avgRating.toFixed(1)}
-              </span>
-            </span>
-          )}
-        </div>
+        {stats}
         {handle && (
-          <button
-            type="button"
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              window.location.assign(`/u/view?handle=${encodeURIComponent(handle)}`);
-            }}
-            className="flex items-center gap-1.5 text-xs text-zinc-400 hover:text-coral-300 transition shrink-0 min-w-0"
-            title={name || `@${handle}`}
-          >
-            <span className="h-5 w-5 rounded-full overflow-hidden bg-zinc-800 grid place-items-center shrink-0">
-              {avatarUrl ? (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img src={avatarUrl} alt="" className="h-full w-full object-cover" />
-              ) : (
-                <span className="text-[9px] font-black text-white bg-gradient-to-br from-coral-500 to-flame-500 h-full w-full grid place-items-center">
-                  {initial}
-                </span>
-              )}
-            </span>
-            <span className="truncate max-w-[6rem]">{name || `@${handle}`}</span>
-          </button>
+          <AuthorChip handle={handle} name={name} avatarUrl={avatarUrl} initial={initial} compact />
         )}
       </div>
     </Link>
+  );
+}
+
+/** Clickable author avatar + name. Stops propagation so it works inside the card Link. */
+function AuthorChip({
+  handle,
+  name,
+  avatarUrl,
+  initial,
+  compact = false,
+}: {
+  handle: string | null;
+  name: string | null;
+  avatarUrl: string | null;
+  initial: string;
+  compact?: boolean;
+}) {
+  const label = name || (handle ? `@${handle}` : 'Someone');
+  const avatarSize = compact ? 'h-5 w-5' : 'h-9 w-9';
+  const initialSize = compact ? 'text-[9px]' : 'text-sm';
+
+  const inner = (
+    <>
+      <span className={`${avatarSize} rounded-full overflow-hidden bg-zinc-800 grid place-items-center shrink-0`}>
+        {avatarUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={avatarUrl} alt="" className="h-full w-full object-cover" />
+        ) : (
+          <span className={`${initialSize} font-black text-white bg-gradient-to-br from-coral-500 to-flame-500 h-full w-full grid place-items-center`}>
+            {initial}
+          </span>
+        )}
+      </span>
+      {compact ? (
+        <span className="truncate max-w-[6rem] text-xs text-zinc-400">{label}</span>
+      ) : (
+        <span className="min-w-0">
+          <span className="block text-sm font-semibold text-zinc-100 leading-tight truncate">{label}</span>
+          {handle && name && (
+            <span className="block text-xs text-zinc-500 leading-tight truncate">@{handle}</span>
+          )}
+        </span>
+      )}
+    </>
+  );
+
+  if (!handle) {
+    // Not clickable without a handle to resolve the profile.
+    return <span className={`flex items-center gap-2 ${compact ? 'min-w-0' : ''}`}>{inner}</span>;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        window.location.assign(`/u/view?handle=${encodeURIComponent(handle)}`);
+      }}
+      className={`flex items-center gap-2 min-w-0 text-left hover:opacity-90 transition ${compact ? 'text-zinc-400 hover:text-coral-300' : ''}`}
+      title={label}
+    >
+      {inner}
+    </button>
   );
 }
 
@@ -127,9 +233,7 @@ function DifficultyDots({ value }: { value: number }) {
       {[1, 2, 3, 4, 5].map((n) => (
         <span
           key={n}
-          className={`h-1.5 w-1.5 rounded-full ${
-            n <= v ? 'bg-coral-400' : 'bg-zinc-700'
-          }`}
+          className={`h-1.5 w-1.5 rounded-full ${n <= v ? 'bg-coral-400' : 'bg-zinc-700'}`}
         />
       ))}
     </span>


### PR DESCRIPTION
The home feed read like a catalog — a 3-up square grid. This makes it a social timeline: one centered column of full-width posts.

## Changes
- **Feed page** (`app/page.tsx`): single `max-w-xl` column, vertical stack (was `max-w-6xl` 3-col grid).
- **RecipeCard**: new `variant` prop. The `feed` variant is a full-width post — author header on top (avatar + name/@handle), larger title, description, tags, stats row. Default `grid` variant is **unchanged**, so discover / search / profile grids keep their compact cards.
- **CookActivityCard** (feed-only): now a full post — author header ("X cooked this"), recipe title, **full-bleed hero photo when the cook has one**, notes, stats.

## Verification
- `npm run build` ✓ (22/22 pages, static export clean)
- Visual: verified via build only — the feed is auth-gated so I couldn't render it logged-in headlessly. Worth an eyeball on the deployed result; easy to tweak spacing/widths.

Grid layouts elsewhere are untouched (verified `RecipeCard` callers in discover/search/u-view still pass no variant → default `grid`).