### PR TITLE
feat(feed): data-rich posts (macros, flavor profile, ingredients, ratings)

### DIFF
--- a/src/components/CookActivityCard.tsx
+++ b/src/components/CookActivityCard.tsx
@@ -2,6 +2,7 @@
 import Link from 'next/link';
 import { Cook, Recipe } from '@/types';
 import { PublicUserProfile } from '@/lib/users';
+import { AuthorRow, MacroPanel, timeAgo } from './FeedBits';
 
 interface Props {
   cook: Cook;
@@ -11,56 +12,58 @@ interface Props {
 }
 
 /**
- * Social-feed post for "X cooked Recipe Y": author header, the recipe being
- * made, an optional hero photo, notes, and a stats row. Visually distinct
- * from RecipeCard so the feed reads as activity, not catalog.
- *
- * Tap goes to the cook detail (`/cooks/view`).
+ * Social-feed post for "X cooked Recipe Y": author header, the dish, an
+ * optional hero photo, the cook's flavor ratings, notes, and the recipe's
+ * nutrition. Visually distinct from a recipe post so the feed reads as
+ * activity, not catalog. Tap → cook detail (`/cooks/view`).
  */
 export function CookActivityCard({ cook, recipe, chef }: Props) {
-  const date = new Date(cook.cookedAt).toLocaleDateString(undefined, {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
-  const chefHandle = chef?.preferredUsername || recipe.authorHandle;
-  const chefName = chef?.displayName;
-  const chefAvatar = chef?.avatarUrl;
-  const chefInitial = (chefName || chefHandle || '?').charAt(0).toUpperCase();
-  const chefLabel = chefName || (chefHandle ? `@${chefHandle}` : 'Someone');
+  const handle = chef?.preferredUsername || recipe.authorHandle || null;
+  const name = chef?.displayName || null;
+  const avatarUrl = chef?.avatarUrl || null;
+
+  const ratingChips = [
+    { label: '★ Overall', value: cook.rating, cls: 'text-coral-300' },
+    { label: '🌶 Spicy', value: cook.spiciness, cls: 'text-flame-400' },
+    { label: '🍬 Sweet', value: cook.sweetness, cls: 'text-pink-300' },
+    { label: '🧂 Salty', value: cook.saltiness, cls: 'text-sky-300' },
+    { label: '🧈 Rich', value: cook.richness, cls: 'text-amber-300' },
+  ].filter((c) => c.value != null);
 
   return (
     <Link
       href={`/cooks/view?id=${encodeURIComponent(cook.cookId)}`}
       className="group block bg-zinc-900/60 border border-zinc-800 hover:border-coral-500/50 rounded-2xl overflow-hidden transition hover:shadow-lg hover:shadow-coral-500/10 focus:outline-none focus:ring-2 focus:ring-coral-400/50"
     >
-      {/* Header */}
-      <div className="flex items-center gap-3 p-5 pb-3">
-        <div className="h-9 w-9 rounded-full overflow-hidden bg-zinc-800 border border-zinc-700 grid place-items-center text-white shrink-0">
-          {chefAvatar ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img src={chefAvatar} alt="" className="h-full w-full object-cover" />
-          ) : (
-            <span className="h-full w-full grid place-items-center bg-gradient-to-br from-coral-500 to-flame-500 text-sm font-black">
-              {chefInitial}
+      {/* Author header */}
+      <div className="p-4 pb-3">
+        <AuthorRow
+          handle={handle}
+          name={name}
+          avatarUrl={avatarUrl}
+          subtitle={
+            <span className="flex items-center gap-1.5">
+              <span>{timeAgo(cook.cookedAt)}</span>
+              <span className="text-zinc-700">·</span>
+              <span>logged a cook</span>
             </span>
-          )}
-        </div>
-        <div className="min-w-0 flex-1">
-          <p className="text-sm leading-tight truncate">
-            <span className="font-semibold text-coral-400">{chefLabel}</span>
-            <span className="text-zinc-400"> cooked this</span>
-          </p>
-          <p className="text-xs text-zinc-500 leading-tight mt-0.5">{date}</p>
-        </div>
-        <span className="text-[11px] uppercase tracking-wider text-zinc-600 font-semibold shrink-0">
-          Cook
-        </span>
+          }
+          right={
+            cook.rating != null ? (
+              <span className="flex items-center gap-1 bg-zinc-950/60 border border-zinc-800 rounded-full px-2.5 py-1 text-sm shrink-0">
+                <span className="text-coral-300" aria-hidden>★</span>
+                <span className="text-zinc-100 font-bold">{cook.rating}</span>
+                <span className="text-zinc-500 text-xs">/5</span>
+              </span>
+            ) : undefined
+          }
+        />
       </div>
 
-      {/* Recipe being cooked */}
-      <div className="px-5 pb-3">
-        <h3 className="font-display text-lg font-black tracking-wide text-zinc-100 group-hover:text-coral-300 transition">
+      {/* The dish */}
+      <div className="px-4 pb-3">
+        <p className="text-[11px] uppercase tracking-wider text-zinc-600 font-semibold">cooked</p>
+        <h3 className="font-display text-xl font-black tracking-wide text-zinc-100 group-hover:text-coral-300 transition">
           {recipe.name}
         </h3>
       </div>
@@ -71,30 +74,46 @@ export function CookActivityCard({ cook, recipe, chef }: Props) {
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={cook.photoUrl}
-            alt={`${chefLabel}'s cook of ${recipe.name}`}
+            alt={`Cook of ${recipe.name}`}
             className="w-full aspect-[4/3] object-cover"
           />
         </div>
       )}
 
-      {/* Body */}
-      <div className={`px-5 pb-5 ${cook.photoUrl ? 'pt-4' : 'pt-0'}`}>
-        {cook.notes && (
-          <p className="text-sm text-zinc-300 line-clamp-3">{cook.notes}</p>
+      <div className="p-4 pt-3 space-y-3">
+        {/* Notes */}
+        {cook.notes && <p className="text-sm text-zinc-300 line-clamp-4">{cook.notes}</p>}
+
+        {/* The cook's flavor ratings */}
+        {ratingChips.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {ratingChips.map((c) => (
+              <span
+                key={c.label}
+                className="inline-flex items-center gap-1 bg-zinc-800/60 rounded-md px-2 py-0.5 text-xs"
+              >
+                <span className={c.cls}>{c.label}</span>
+                <span className="text-zinc-200 font-semibold">{c.value}</span>
+              </span>
+            ))}
+          </div>
         )}
-        <div className="text-xs text-zinc-500 flex items-center gap-4 mt-3">
-          {cook.rating != null && (
-            <span className="flex items-center gap-1">
-              <span className="text-coral-300">★</span>
-              <span className="text-zinc-300 font-semibold">{cook.rating}/5</span>
-            </span>
-          )}
+
+        {/* Recipe nutrition — data even when there's no photo */}
+        <MacroPanel macros={recipe.macros} scope={recipe.macrosScope} />
+
+        {/* Footer */}
+        <div className="flex items-center gap-5 pt-2 border-t border-zinc-800/60 text-sm text-zinc-400">
           {cook.diners.length > 0 && (
-            <span>
-              <span className="text-zinc-300 font-semibold">{cook.diners.length}</span>{' '}
-              {cook.diners.length === 1 ? 'diner' : 'diners'}
+            <span className="flex items-center gap-1.5">
+              <span aria-hidden>🍽</span>
+              <span className="text-zinc-300 font-semibold">{cook.diners.length}</span>
+              <span className="text-zinc-500">{cook.diners.length === 1 ? 'diner' : 'diners'}</span>
             </span>
           )}
+          <span className="ml-auto text-coral-400 font-semibold group-hover:text-coral-300">
+            View cook →
+          </span>
         </div>
       </div>
     </Link>

--- a/src/components/FeedBits.tsx
+++ b/src/components/FeedBits.tsx
@@ -1,0 +1,164 @@
+'use client';
+import { Recipe, Cook, Macros, MacrosScope, Ingredient, PROTEIN_LABELS } from '@/types';
+
+/** Relative time, e.g. "3h ago". Mirrors the helper used in the comment threads. */
+export function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const min = Math.round(diff / 60_000);
+  if (min < 1) return 'just now';
+  if (min < 60) return `${min}m ago`;
+  const hrs = Math.round(min / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.round(hrs / 24);
+  if (days < 30) return `${days}d ago`;
+  if (days < 365) return `${Math.round(days / 30)}mo ago`;
+  return `${Math.round(days / 365)}y ago`;
+}
+
+/** Author avatar + name. Clickable to the profile; stops propagation so it
+ *  works inside a card that is itself a Link. */
+export function AuthorRow({
+  handle,
+  name,
+  avatarUrl,
+  subtitle,
+  right,
+}: {
+  handle: string | null;
+  name: string | null;
+  avatarUrl: string | null;
+  subtitle?: React.ReactNode;
+  right?: React.ReactNode;
+}) {
+  const label = name || (handle ? `@${handle}` : 'Someone');
+  const initial = (name || handle || '?').charAt(0).toUpperCase();
+
+  const avatar = (
+    <span className="h-10 w-10 rounded-full overflow-hidden bg-zinc-800 grid place-items-center shrink-0 ring-1 ring-zinc-700/60">
+      {avatarUrl ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={avatarUrl} alt="" className="h-full w-full object-cover" />
+      ) : (
+        <span className="h-full w-full grid place-items-center bg-gradient-to-br from-coral-500 to-flame-500 text-sm font-black text-white">
+          {initial}
+        </span>
+      )}
+    </span>
+  );
+
+  const goProfile = (e: React.MouseEvent) => {
+    if (!handle) return;
+    e.preventDefault();
+    e.stopPropagation();
+    window.location.assign(`/u/view?handle=${encodeURIComponent(handle)}`);
+  };
+
+  return (
+    <div className="flex items-center gap-3">
+      <button type="button" onClick={goProfile} className="shrink-0" aria-label={`View ${label}`}>
+        {avatar}
+      </button>
+      <div className="min-w-0 flex-1">
+        <button
+          type="button"
+          onClick={goProfile}
+          className="block text-sm font-semibold text-zinc-100 leading-tight truncate text-left hover:text-coral-300 transition"
+          title={label}
+        >
+          {label}
+        </button>
+        {subtitle && (
+          <div className="text-xs text-zinc-500 leading-tight mt-0.5 truncate">{subtitle}</div>
+        )}
+      </div>
+      {right}
+    </div>
+  );
+}
+
+const hasMacros = (m?: Macros | null) =>
+  !!m && (m.calories > 0 || m.protein > 0 || m.carbs > 0 || m.fat > 0);
+
+/** Nutrition panel — the "data" hero. Four big stats with a per-serving note. */
+export function MacroPanel({ macros, scope }: { macros: Macros; scope: MacrosScope }) {
+  if (!hasMacros(macros)) return null;
+  const cells: [string, string, string][] = [
+    ['kcal', String(Math.round(macros.calories)), 'text-coral-300'],
+    ['protein', `${Math.round(macros.protein)}g`, 'text-emerald-300'],
+    ['carbs', `${Math.round(macros.carbs)}g`, 'text-sky-300'],
+    ['fat', `${Math.round(macros.fat)}g`, 'text-amber-300'],
+  ];
+  return (
+    <div className="rounded-xl bg-zinc-950/60 border border-zinc-800 p-3">
+      <div className="grid grid-cols-4 divide-x divide-zinc-800">
+        {cells.map(([label, value, color]) => (
+          <div key={label} className="px-1 text-center">
+            <div className={`font-display text-lg font-black leading-none ${color}`}>{value}</div>
+            <div className="text-[10px] uppercase tracking-wider text-zinc-500 mt-1">{label}</div>
+          </div>
+        ))}
+      </div>
+      <div className="text-[10px] text-zinc-600 text-center mt-2">
+        {scope === 'per-serving' ? 'per serving' : 'per recipe'}
+      </div>
+    </div>
+  );
+}
+
+type Axis = { key: string; label: string; avg: number | null; count: number; color: string };
+
+/** Flavor-profile bars (spicy/sweet/salty/rich) — only axes with ratings. */
+export function FlavorProfile({ recipe }: { recipe: Recipe }) {
+  const axes: Axis[] = [
+    { key: 'spicy', label: 'Spicy', avg: recipe.spicinessAvg, count: recipe.spicinessCount, color: 'bg-flame-500' },
+    { key: 'sweet', label: 'Sweet', avg: recipe.sweetnessAvg, count: recipe.sweetnessCount, color: 'bg-pink-400' },
+    { key: 'salty', label: 'Salty', avg: recipe.saltinessAvg, count: recipe.saltinessCount, color: 'bg-sky-400' },
+    { key: 'rich', label: 'Rich', avg: recipe.richnessAvg, count: recipe.richnessCount, color: 'bg-amber-400' },
+  ].filter((a) => a.count > 0 && a.avg != null) as Axis[];
+  if (axes.length === 0) return null;
+  return (
+    <div className="grid grid-cols-2 gap-x-4 gap-y-1.5">
+      {axes.map((a) => (
+        <div key={a.key} className="flex items-center gap-2">
+          <span className="text-[11px] text-zinc-500 w-9 shrink-0">{a.label}</span>
+          <span className="h-1.5 flex-1 rounded-full bg-zinc-800 overflow-hidden">
+            <span
+              className={`block h-full rounded-full ${a.color}`}
+              style={{ width: `${((a.avg as number) / 5) * 100}%` }}
+            />
+          </span>
+          <span className="text-[11px] text-zinc-400 font-semibold w-6 text-right shrink-0">
+            {(a.avg as number).toFixed(1)}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** "12 ingredients · chicken breast, broccoli, bell pepper +9" */
+export function ingredientSummary(recipe: Recipe): { count: number; preview: string } | null {
+  const items = recipe.ingredients ?? [];
+  if (items.length === 0) return null;
+  const names = items
+    .map((i: string | Ingredient) => (typeof i === 'string' ? i : i?.name))
+    .filter((n): n is string => !!n && n.trim().length > 0);
+  if (names.length === 0) return null;
+  const shown = names.slice(0, 3).join(', ');
+  const extra = names.length - 3;
+  return { count: names.length, preview: extra > 0 ? `${shown} +${extra}` : shown };
+}
+
+export function proteinLabels(recipe: Recipe): string[] {
+  return (recipe.proteinTypes ?? [])
+    .filter((p) => p !== 'none' && p !== 'other')
+    .map((p) => PROTEIN_LABELS[p] ?? p);
+}
+
+/** Cook hero photo or, when absent, the recipe's macro panel as a stat header. */
+export function macrosForCookRecipe(recipe: Recipe): { macros: Macros; scope: MacrosScope } {
+  return { macros: recipe.macros, scope: recipe.macrosScope };
+}
+
+export { hasMacros };
+export type { Cook };

--- a/src/components/RecipeCard.tsx
+++ b/src/components/RecipeCard.tsx
@@ -4,6 +4,14 @@ import { Recipe, TAG_LABELS } from '@/types';
 import { PublicUserProfile } from '@/lib/users';
 import { PrivacyBadge } from './PrivacyBadge';
 import LikeButton from './LikeButton';
+import {
+  AuthorRow,
+  MacroPanel,
+  FlavorProfile,
+  ingredientSummary,
+  proteinLabels,
+  timeAgo,
+} from './FeedBits';
 
 interface Props {
   recipe: Recipe;
@@ -11,7 +19,7 @@ interface Props {
   author?: PublicUserProfile | null;
   /**
    * 'grid' (default) — compact card for the discover/search/profile grids.
-   * 'feed' — full-width social-style post for the home feed.
+   * 'feed' — full-width, data-rich social post for the home feed.
    */
   variant?: 'grid' | 'feed';
 }
@@ -20,79 +28,88 @@ export function RecipeCard({ recipe, author, variant = 'grid' }: Props) {
   const handle = author?.preferredUsername ?? recipe.authorHandle ?? null;
   const name = author?.displayName ?? null;
   const avatarUrl = author?.avatarUrl ?? null;
-  const initial = (name || handle || '?').charAt(0).toUpperCase();
-  // Difficulty is 1..5 going forward, but back-compat for any unmigrated rows.
   const diff = typeof recipe.difficulty === 'number' ? recipe.difficulty : 3;
   const tags = recipe.tags ?? [];
+  const href = `/recipes/view?id=${encodeURIComponent(recipe.recipeId)}`;
 
-  const meta = (
-    <div className="text-xs flex items-center gap-1.5 text-zinc-400">
-      <DifficultyDots value={diff} />
-      {recipe.timeMinutes > 0 && (
-        <>
-          <span className="text-zinc-700">·</span>
-          <span>{recipe.timeMinutes}m</span>
-        </>
-      )}
-      {recipe.servings > 0 && (
-        <>
-          <span className="text-zinc-700">·</span>
-          <span>{recipe.servings} {recipe.servings === 1 ? 'serv' : 'servs'}</span>
-        </>
-      )}
-    </div>
-  );
-
-  const stats = (
-    <div className="text-xs text-zinc-500 flex items-center gap-3 min-w-0">
-      <LikeButton
-        recipeId={recipe.recipeId}
-        initialCount={recipe.likeCount ?? 0}
-        initialLiked={recipe.likedByMe ?? false}
-        compact
-      />
-      <span className="truncate">
-        <span className="text-zinc-300 font-semibold">{recipe.cookCount}</span>{' '}
-        {recipe.cookCount === 1 ? 'cook' : 'cooks'}
-      </span>
-      {recipe.ratingCount > 0 && recipe.avgRating != null && (
-        <span className="flex items-center gap-1 shrink-0">
-          <span className="text-coral-300">★</span>
-          <span className="text-zinc-300 font-semibold">{recipe.avgRating.toFixed(1)}</span>
-        </span>
-      )}
-    </div>
-  );
-
-  // ---- Feed variant: full-width social post -------------------------------
+  // ---- Feed variant: data-rich social post --------------------------------
   if (variant === 'feed') {
+    const ingr = ingredientSummary(recipe);
+    const proteins = proteinLabels(recipe);
     return (
       <Link
-        href={`/recipes/view?id=${encodeURIComponent(recipe.recipeId)}`}
-        className="group block bg-zinc-900/60 border border-zinc-800 hover:border-coral-500/50 rounded-2xl p-5 transition hover:shadow-lg hover:shadow-coral-500/10 focus:outline-none focus:ring-2 focus:ring-coral-400/50"
+        href={href}
+        className="group block bg-zinc-900/60 border border-zinc-800 hover:border-coral-500/50 rounded-2xl transition hover:shadow-lg hover:shadow-coral-500/10 focus:outline-none focus:ring-2 focus:ring-coral-400/50"
       >
         {/* Author header */}
-        <div className="flex items-center gap-3 mb-3">
-          <AuthorChip handle={handle} name={name} avatarUrl={avatarUrl} initial={initial} />
-          <div className="ml-auto flex items-center gap-2">
-            <span className="text-[11px] uppercase tracking-wider text-zinc-600 font-semibold">
-              Recipe
-            </span>
-            <PrivacyBadge privacy={recipe.privacy} />
-          </div>
+        <div className="p-4 pb-0">
+          <AuthorRow
+            handle={handle}
+            name={name}
+            avatarUrl={avatarUrl}
+            subtitle={
+              <span className="flex items-center gap-1.5">
+                <span>{timeAgo(recipe.createdAt)}</span>
+                <span className="text-zinc-700">·</span>
+                <span>posted a recipe</span>
+              </span>
+            }
+            right={<PrivacyBadge privacy={recipe.privacy} />}
+          />
         </div>
 
-        <h3 className="font-display text-xl font-black tracking-wide text-zinc-100 group-hover:text-coral-300 transition">
-          {recipe.name}
-        </h3>
-        <div className="mt-1.5">{meta}</div>
+        {/* Title + description */}
+        <div className="px-4 pt-3">
+          <h3 className="font-display text-xl font-black tracking-wide text-zinc-100 group-hover:text-coral-300 transition">
+            {recipe.name}
+          </h3>
+          {recipe.description && (
+            <p className="text-sm text-zinc-400 line-clamp-2 mt-1">{recipe.description}</p>
+          )}
+        </div>
 
-        {recipe.description && (
-          <p className="text-sm text-zinc-400 line-clamp-3 mt-2">{recipe.description}</p>
+        {/* Macro / nutrition panel */}
+        <div className="px-4 mt-3">
+          <MacroPanel macros={recipe.macros} scope={recipe.macrosScope} />
+        </div>
+
+        {/* Metadata chips */}
+        <div className="px-4 mt-3 flex flex-wrap items-center gap-x-3 gap-y-1.5 text-xs text-zinc-400">
+          <span className="flex items-center gap-1.5">
+            <span className="text-zinc-500">Difficulty</span>
+            <DifficultyDots value={diff} />
+          </span>
+          {recipe.timeMinutes > 0 && <Chip>⏱ {recipe.timeMinutes} min</Chip>}
+          {recipe.servings > 0 && (
+            <Chip>🍽 {recipe.servings} {recipe.servings === 1 ? 'serving' : 'servings'}</Chip>
+          )}
+          {ingr && <Chip>🧾 {ingr.count} ingredients</Chip>}
+          {proteins.slice(0, 2).map((p) => (
+            <Chip key={p}>🥩 {p}</Chip>
+          ))}
+        </div>
+
+        {/* Flavor profile (only when rated) */}
+        {(recipe.spicinessCount > 0 ||
+          recipe.sweetnessCount > 0 ||
+          recipe.saltinessCount > 0 ||
+          recipe.richnessCount > 0) && (
+          <div className="px-4 mt-3">
+            <FlavorProfile recipe={recipe} />
+          </div>
         )}
 
+        {/* Ingredient preview */}
+        {ingr && (
+          <p className="px-4 mt-3 text-xs text-zinc-500 line-clamp-1">
+            <span className="text-zinc-600">Ingredients · </span>
+            {ingr.preview}
+          </p>
+        )}
+
+        {/* Tags */}
         {tags.length > 0 && (
-          <div className="flex flex-wrap gap-1.5 mt-3">
+          <div className="px-4 mt-3 flex flex-wrap gap-1.5">
             {tags.slice(0, 6).map((t) => (
               <span
                 key={t}
@@ -102,22 +119,41 @@ export function RecipeCard({ recipe, author, variant = 'grid' }: Props) {
               </span>
             ))}
             {tags.length > 6 && (
-              <span className="inline-block text-[11px] text-zinc-500 px-1 py-0.5">
-                +{tags.length - 6}
-              </span>
+              <span className="text-[11px] text-zinc-500 px-1 py-0.5">+{tags.length - 6}</span>
             )}
           </div>
         )}
 
-        <div className="flex items-center pt-3 mt-3 border-t border-zinc-800/60">{stats}</div>
+        {/* Engagement bar */}
+        <div className="flex items-center gap-5 px-4 py-3 mt-3 border-t border-zinc-800/60 text-sm text-zinc-400">
+          <LikeButton
+            recipeId={recipe.recipeId}
+            initialCount={recipe.likeCount ?? 0}
+            initialLiked={recipe.likedByMe ?? false}
+            compact
+          />
+          <span className="flex items-center gap-1.5">
+            <span aria-hidden>🍳</span>
+            <span className="text-zinc-300 font-semibold">{recipe.cookCount}</span>
+            <span className="text-zinc-500">{recipe.cookCount === 1 ? 'cook' : 'cooks'}</span>
+          </span>
+          {recipe.ratingCount > 0 && recipe.avgRating != null && (
+            <span className="flex items-center gap-1.5">
+              <span className="text-coral-300" aria-hidden>★</span>
+              <span className="text-zinc-300 font-semibold">{recipe.avgRating.toFixed(1)}</span>
+              <span className="text-zinc-500">({recipe.ratingCount})</span>
+            </span>
+          )}
+        </div>
       </Link>
     );
   }
 
   // ---- Grid variant (default): compact catalog card -----------------------
+  const initial = (name || handle || '?').charAt(0).toUpperCase();
   return (
     <Link
-      href={`/recipes/view?id=${encodeURIComponent(recipe.recipeId)}`}
+      href={href}
       className="group bg-zinc-900/60 border border-zinc-800 hover:border-coral-500/50 rounded-xl p-4 space-y-3 transition hover:shadow-lg hover:shadow-coral-500/10 focus:outline-none focus:ring-2 focus:ring-coral-400/50 block"
     >
       <div className="flex items-start justify-between gap-2">
@@ -125,7 +161,21 @@ export function RecipeCard({ recipe, author, variant = 'grid' }: Props) {
           <h3 className="font-bold text-base truncate group-hover:text-coral-300 transition">
             {recipe.name}
           </h3>
-          <div className="mt-0.5">{meta}</div>
+          <div className="text-xs flex items-center gap-1.5 mt-0.5 text-zinc-400">
+            <DifficultyDots value={diff} />
+            {recipe.timeMinutes > 0 && (
+              <>
+                <span className="text-zinc-700">·</span>
+                <span>{recipe.timeMinutes}m</span>
+              </>
+            )}
+            {recipe.servings > 0 && (
+              <>
+                <span className="text-zinc-700">·</span>
+                <span>{recipe.servings} {recipe.servings === 1 ? 'serv' : 'servs'}</span>
+              </>
+            )}
+          </div>
         </div>
         <PrivacyBadge privacy={recipe.privacy} />
       </div>
@@ -145,84 +195,64 @@ export function RecipeCard({ recipe, author, variant = 'grid' }: Props) {
             </span>
           ))}
           {tags.length > 4 && (
-            <span className="inline-block text-[10px] text-zinc-500 px-1">
-              +{tags.length - 4}
-            </span>
+            <span className="inline-block text-[10px] text-zinc-500 px-1">+{tags.length - 4}</span>
           )}
         </div>
       )}
 
       <div className="flex items-center justify-between pt-1 border-t border-zinc-800/60 gap-2">
-        {stats}
+        <div className="text-xs text-zinc-500 flex items-center gap-3 min-w-0">
+          <LikeButton
+            recipeId={recipe.recipeId}
+            initialCount={recipe.likeCount ?? 0}
+            initialLiked={recipe.likedByMe ?? false}
+            compact
+          />
+          <span className="truncate">
+            <span className="text-zinc-300 font-semibold">{recipe.cookCount}</span>{' '}
+            {recipe.cookCount === 1 ? 'cook' : 'cooks'}
+          </span>
+          {recipe.ratingCount > 0 && recipe.avgRating != null && (
+            <span className="flex items-center gap-1 shrink-0">
+              <span className="text-coral-300">★</span>
+              <span className="text-zinc-300 font-semibold">{recipe.avgRating.toFixed(1)}</span>
+            </span>
+          )}
+        </div>
         {handle && (
-          <AuthorChip handle={handle} name={name} avatarUrl={avatarUrl} initial={initial} compact />
+          <button
+            type="button"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              window.location.assign(`/u/view?handle=${encodeURIComponent(handle)}`);
+            }}
+            className="flex items-center gap-1.5 text-xs text-zinc-400 hover:text-coral-300 transition shrink-0 min-w-0"
+            title={name || `@${handle}`}
+          >
+            <span className="h-5 w-5 rounded-full overflow-hidden bg-zinc-800 grid place-items-center shrink-0">
+              {avatarUrl ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={avatarUrl} alt="" className="h-full w-full object-cover" />
+              ) : (
+                <span className="text-[9px] font-black text-white bg-gradient-to-br from-coral-500 to-flame-500 h-full w-full grid place-items-center">
+                  {initial}
+                </span>
+              )}
+            </span>
+            <span className="truncate max-w-[6rem]">{name || `@${handle}`}</span>
+          </button>
         )}
       </div>
     </Link>
   );
 }
 
-/** Clickable author avatar + name. Stops propagation so it works inside the card Link. */
-function AuthorChip({
-  handle,
-  name,
-  avatarUrl,
-  initial,
-  compact = false,
-}: {
-  handle: string | null;
-  name: string | null;
-  avatarUrl: string | null;
-  initial: string;
-  compact?: boolean;
-}) {
-  const label = name || (handle ? `@${handle}` : 'Someone');
-  const avatarSize = compact ? 'h-5 w-5' : 'h-9 w-9';
-  const initialSize = compact ? 'text-[9px]' : 'text-sm';
-
-  const inner = (
-    <>
-      <span className={`${avatarSize} rounded-full overflow-hidden bg-zinc-800 grid place-items-center shrink-0`}>
-        {avatarUrl ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img src={avatarUrl} alt="" className="h-full w-full object-cover" />
-        ) : (
-          <span className={`${initialSize} font-black text-white bg-gradient-to-br from-coral-500 to-flame-500 h-full w-full grid place-items-center`}>
-            {initial}
-          </span>
-        )}
-      </span>
-      {compact ? (
-        <span className="truncate max-w-[6rem] text-xs text-zinc-400">{label}</span>
-      ) : (
-        <span className="min-w-0">
-          <span className="block text-sm font-semibold text-zinc-100 leading-tight truncate">{label}</span>
-          {handle && name && (
-            <span className="block text-xs text-zinc-500 leading-tight truncate">@{handle}</span>
-          )}
-        </span>
-      )}
-    </>
-  );
-
-  if (!handle) {
-    // Not clickable without a handle to resolve the profile.
-    return <span className={`flex items-center gap-2 ${compact ? 'min-w-0' : ''}`}>{inner}</span>;
-  }
-
+function Chip({ children }: { children: React.ReactNode }) {
   return (
-    <button
-      type="button"
-      onClick={(e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        window.location.assign(`/u/view?handle=${encodeURIComponent(handle)}`);
-      }}
-      className={`flex items-center gap-2 min-w-0 text-left hover:opacity-90 transition ${compact ? 'text-zinc-400 hover:text-coral-300' : ''}`}
-      title={label}
-    >
-      {inner}
-    </button>
+    <span className="inline-flex items-center gap-1 bg-zinc-800/60 rounded-md px-2 py-0.5">
+      {children}
+    </span>
   );
 }
 


### PR DESCRIPTION
Follow-up to #48 — the first pass was full-width but too sparse ("no info, no data"). This makes each feed post detailed, surfacing data we already store but never showed.

Informed by how food social apps present recipes (nutrition panel, core metadata, ratings/reviews, ingredients, engagement — single-column detail).

## New: `FeedBits.tsx` (shared)
`AuthorRow`, `MacroPanel` (calories + protein/carbs/fat), `FlavorProfile` (spicy/sweet/salty/rich bars built from the per-axis averages), ingredient summary, `timeAgo`.

## Recipe post now shows
author header · title + description · **nutrition panel** · metadata chips (time / difficulty / servings / **ingredient count** / protein) · **flavor-profile bars** (when rated) · ingredient preview · tags · engagement bar (likes / cooks / rating **with counts**).

## Cook post now shows
author header · dish title · **full-bleed hero photo** · the cook's **per-axis ratings** as chips · notes · the recipe's **nutrition panel** · diner count.

Grid variant + discover/search/profile untouched.

## Verification
`npm run build` ✓ (compiles, 22/22 static pages). The home feed is auth-gated so I verified via build, not a headless screenshot — your seeded recipes/cooks populate your own feed, so it's visible immediately on deploy.